### PR TITLE
Enable cascading.avro to handle arbitrarily large avro schema

### DIFF
--- a/scheme/pom.xml
+++ b/scheme/pom.xml
@@ -59,6 +59,9 @@
                         <source>1.6</source>
                         <target>1.6</target>
                         <encoding>UTF-8</encoding>
+                        <testExcludes>
+                            <exclude>**/cascading/avro/TestExtraLarge.java</exclude>
+                        </testExcludes>
                     </configuration>
                 </plugin>
             </plugins>

--- a/scheme/src/main/java/cascading/avro/AvroScheme.java
+++ b/scheme/src/main/java/cascading/avro/AvroScheme.java
@@ -114,7 +114,11 @@ public class AvroScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     protected static Schema readSchema(java.io.ObjectInputStream in) throws IOException {
         final Schema.Parser parser = new Schema.Parser();
-        return parser.parse(in.readUTF());
+        try {
+            return parser.parse(in.readObject().toString());
+        } catch (ClassNotFoundException cce) {
+            throw new RuntimeException("Unable to read schema which is expected to be written as a java string", cce);
+        }
     }
 
     /**
@@ -321,14 +325,12 @@ public class AvroScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
                     stream = new BufferedInputStream(fs.open(statusPath));
                     reader = new DataFileStream(stream, new GenericDatumReader());
                     return reader.getSchema();
-                }
-                finally {
+                } finally {
                     if (reader == null) {
                         if (stream != null) {
                             stream.close();
                         }
-                    }
-                    else {
+                    } else {
                         reader.close();
                     }
                 }
@@ -352,7 +354,7 @@ public class AvroScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
 
     private void writeObject(java.io.ObjectOutputStream out)
             throws IOException {
-        out.writeUTF(this.schema.toString());
+        out.writeObject(this.schema.toString());
     }
 
     private void readObject(java.io.ObjectInputStream in)

--- a/scheme/src/test/java/cascading/avro/AvroSchemeTest.java
+++ b/scheme/src/test/java/cascading/avro/AvroSchemeTest.java
@@ -713,4 +713,22 @@ public class AvroSchemeTest extends Assert {
     wcFlow2.complete();
 
   }
+
+  @Test
+  public void testSerializeExtraLargeSchema() throws Exception {
+    final Schema extraLarge = new Schema.Parser().parse(getClass().getResourceAsStream(
+            "test-extra-large.avsc"));
+    final AvroScheme expected = new AvroScheme(extraLarge);
+
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(bytes);
+    oos.writeObject(expected);
+    oos.close();
+
+    final ObjectInputStream iis = new ObjectInputStream(
+            new ByteArrayInputStream(bytes.toByteArray()));
+    final AvroScheme actual = (AvroScheme) iis.readObject();
+
+    assertEquals(expected, actual);
+  }
 }

--- a/scheme/src/test/resources/cascading/avro/test-extra-large.avsc
+++ b/scheme/src/test/resources/cascading/avro/test-extra-large.avsc
@@ -1,0 +1,5378 @@
+{
+    "type": "record",
+    "name": "TestExtraLarge",
+    "namespace": "com.maxpoint.cascading.avro",
+    "doc": "Extra large schema",
+    "fields": [
+        {
+            "name": "field0",
+            "type": "string",
+            "doc": "doc for field0"
+        },
+        {
+            "name": "field1",
+            "type": "string",
+            "doc": "doc for field1"
+        },
+        {
+            "name": "field2",
+            "type": "string",
+            "doc": "doc for field2"
+        },
+        {
+            "name": "field3",
+            "type": "string",
+            "doc": "doc for field3"
+        },
+        {
+            "name": "field4",
+            "type": "string",
+            "doc": "doc for field4"
+        },
+        {
+            "name": "field5",
+            "type": "string",
+            "doc": "doc for field5"
+        },
+        {
+            "name": "field6",
+            "type": "string",
+            "doc": "doc for field6"
+        },
+        {
+            "name": "field7",
+            "type": "string",
+            "doc": "doc for field7"
+        },
+        {
+            "name": "field8",
+            "type": "string",
+            "doc": "doc for field8"
+        },
+        {
+            "name": "field9",
+            "type": "string",
+            "doc": "doc for field9"
+        },
+        {
+            "name": "field10",
+            "type": "string",
+            "doc": "doc for field10"
+        },
+        {
+            "name": "field11",
+            "type": "string",
+            "doc": "doc for field11"
+        },
+        {
+            "name": "field12",
+            "type": "string",
+            "doc": "doc for field12"
+        },
+        {
+            "name": "field13",
+            "type": "string",
+            "doc": "doc for field13"
+        },
+        {
+            "name": "field14",
+            "type": "string",
+            "doc": "doc for field14"
+        },
+        {
+            "name": "field15",
+            "type": "string",
+            "doc": "doc for field15"
+        },
+        {
+            "name": "field16",
+            "type": "string",
+            "doc": "doc for field16"
+        },
+        {
+            "name": "field17",
+            "type": "string",
+            "doc": "doc for field17"
+        },
+        {
+            "name": "field18",
+            "type": "string",
+            "doc": "doc for field18"
+        },
+        {
+            "name": "field19",
+            "type": "string",
+            "doc": "doc for field19"
+        },
+        {
+            "name": "field20",
+            "type": "string",
+            "doc": "doc for field20"
+        },
+        {
+            "name": "field21",
+            "type": "string",
+            "doc": "doc for field21"
+        },
+        {
+            "name": "field22",
+            "type": "string",
+            "doc": "doc for field22"
+        },
+        {
+            "name": "field23",
+            "type": "string",
+            "doc": "doc for field23"
+        },
+        {
+            "name": "field24",
+            "type": "string",
+            "doc": "doc for field24"
+        },
+        {
+            "name": "field25",
+            "type": "string",
+            "doc": "doc for field25"
+        },
+        {
+            "name": "field26",
+            "type": "string",
+            "doc": "doc for field26"
+        },
+        {
+            "name": "field27",
+            "type": "string",
+            "doc": "doc for field27"
+        },
+        {
+            "name": "field28",
+            "type": "string",
+            "doc": "doc for field28"
+        },
+        {
+            "name": "field29",
+            "type": "string",
+            "doc": "doc for field29"
+        },
+        {
+            "name": "field30",
+            "type": "string",
+            "doc": "doc for field30"
+        },
+        {
+            "name": "field31",
+            "type": "string",
+            "doc": "doc for field31"
+        },
+        {
+            "name": "field32",
+            "type": "string",
+            "doc": "doc for field32"
+        },
+        {
+            "name": "field33",
+            "type": "string",
+            "doc": "doc for field33"
+        },
+        {
+            "name": "field34",
+            "type": "string",
+            "doc": "doc for field34"
+        },
+        {
+            "name": "field35",
+            "type": "string",
+            "doc": "doc for field35"
+        },
+        {
+            "name": "field36",
+            "type": "string",
+            "doc": "doc for field36"
+        },
+        {
+            "name": "field37",
+            "type": "string",
+            "doc": "doc for field37"
+        },
+        {
+            "name": "field38",
+            "type": "string",
+            "doc": "doc for field38"
+        },
+        {
+            "name": "field39",
+            "type": "string",
+            "doc": "doc for field39"
+        },
+        {
+            "name": "field40",
+            "type": "string",
+            "doc": "doc for field40"
+        },
+        {
+            "name": "field41",
+            "type": "string",
+            "doc": "doc for field41"
+        },
+        {
+            "name": "field42",
+            "type": "string",
+            "doc": "doc for field42"
+        },
+        {
+            "name": "field43",
+            "type": "string",
+            "doc": "doc for field43"
+        },
+        {
+            "name": "field44",
+            "type": "string",
+            "doc": "doc for field44"
+        },
+        {
+            "name": "field45",
+            "type": "string",
+            "doc": "doc for field45"
+        },
+        {
+            "name": "field46",
+            "type": "string",
+            "doc": "doc for field46"
+        },
+        {
+            "name": "field47",
+            "type": "string",
+            "doc": "doc for field47"
+        },
+        {
+            "name": "field48",
+            "type": "string",
+            "doc": "doc for field48"
+        },
+        {
+            "name": "field49",
+            "type": "string",
+            "doc": "doc for field49"
+        },
+        {
+            "name": "field50",
+            "type": "string",
+            "doc": "doc for field50"
+        },
+        {
+            "name": "field51",
+            "type": "string",
+            "doc": "doc for field51"
+        },
+        {
+            "name": "field52",
+            "type": "string",
+            "doc": "doc for field52"
+        },
+        {
+            "name": "field53",
+            "type": "string",
+            "doc": "doc for field53"
+        },
+        {
+            "name": "field54",
+            "type": "string",
+            "doc": "doc for field54"
+        },
+        {
+            "name": "field55",
+            "type": "string",
+            "doc": "doc for field55"
+        },
+        {
+            "name": "field56",
+            "type": "string",
+            "doc": "doc for field56"
+        },
+        {
+            "name": "field57",
+            "type": "string",
+            "doc": "doc for field57"
+        },
+        {
+            "name": "field58",
+            "type": "string",
+            "doc": "doc for field58"
+        },
+        {
+            "name": "field59",
+            "type": "string",
+            "doc": "doc for field59"
+        },
+        {
+            "name": "field60",
+            "type": "string",
+            "doc": "doc for field60"
+        },
+        {
+            "name": "field61",
+            "type": "string",
+            "doc": "doc for field61"
+        },
+        {
+            "name": "field62",
+            "type": "string",
+            "doc": "doc for field62"
+        },
+        {
+            "name": "field63",
+            "type": "string",
+            "doc": "doc for field63"
+        },
+        {
+            "name": "field64",
+            "type": "string",
+            "doc": "doc for field64"
+        },
+        {
+            "name": "field65",
+            "type": "string",
+            "doc": "doc for field65"
+        },
+        {
+            "name": "field66",
+            "type": "string",
+            "doc": "doc for field66"
+        },
+        {
+            "name": "field67",
+            "type": "string",
+            "doc": "doc for field67"
+        },
+        {
+            "name": "field68",
+            "type": "string",
+            "doc": "doc for field68"
+        },
+        {
+            "name": "field69",
+            "type": "string",
+            "doc": "doc for field69"
+        },
+        {
+            "name": "field70",
+            "type": "string",
+            "doc": "doc for field70"
+        },
+        {
+            "name": "field71",
+            "type": "string",
+            "doc": "doc for field71"
+        },
+        {
+            "name": "field72",
+            "type": "string",
+            "doc": "doc for field72"
+        },
+        {
+            "name": "field73",
+            "type": "string",
+            "doc": "doc for field73"
+        },
+        {
+            "name": "field74",
+            "type": "string",
+            "doc": "doc for field74"
+        },
+        {
+            "name": "field75",
+            "type": "string",
+            "doc": "doc for field75"
+        },
+        {
+            "name": "field76",
+            "type": "string",
+            "doc": "doc for field76"
+        },
+        {
+            "name": "field77",
+            "type": "string",
+            "doc": "doc for field77"
+        },
+        {
+            "name": "field78",
+            "type": "string",
+            "doc": "doc for field78"
+        },
+        {
+            "name": "field79",
+            "type": "string",
+            "doc": "doc for field79"
+        },
+        {
+            "name": "field80",
+            "type": "string",
+            "doc": "doc for field80"
+        },
+        {
+            "name": "field81",
+            "type": "string",
+            "doc": "doc for field81"
+        },
+        {
+            "name": "field82",
+            "type": "string",
+            "doc": "doc for field82"
+        },
+        {
+            "name": "field83",
+            "type": "string",
+            "doc": "doc for field83"
+        },
+        {
+            "name": "field84",
+            "type": "string",
+            "doc": "doc for field84"
+        },
+        {
+            "name": "field85",
+            "type": "string",
+            "doc": "doc for field85"
+        },
+        {
+            "name": "field86",
+            "type": "string",
+            "doc": "doc for field86"
+        },
+        {
+            "name": "field87",
+            "type": "string",
+            "doc": "doc for field87"
+        },
+        {
+            "name": "field88",
+            "type": "string",
+            "doc": "doc for field88"
+        },
+        {
+            "name": "field89",
+            "type": "string",
+            "doc": "doc for field89"
+        },
+        {
+            "name": "field90",
+            "type": "string",
+            "doc": "doc for field90"
+        },
+        {
+            "name": "field91",
+            "type": "string",
+            "doc": "doc for field91"
+        },
+        {
+            "name": "field92",
+            "type": "string",
+            "doc": "doc for field92"
+        },
+        {
+            "name": "field93",
+            "type": "string",
+            "doc": "doc for field93"
+        },
+        {
+            "name": "field94",
+            "type": "string",
+            "doc": "doc for field94"
+        },
+        {
+            "name": "field95",
+            "type": "string",
+            "doc": "doc for field95"
+        },
+        {
+            "name": "field96",
+            "type": "string",
+            "doc": "doc for field96"
+        },
+        {
+            "name": "field97",
+            "type": "string",
+            "doc": "doc for field97"
+        },
+        {
+            "name": "field98",
+            "type": "string",
+            "doc": "doc for field98"
+        },
+        {
+            "name": "field99",
+            "type": "string",
+            "doc": "doc for field99"
+        },
+        {
+            "name": "field100",
+            "type": "string",
+            "doc": "doc for field100"
+        },
+        {
+            "name": "field101",
+            "type": "string",
+            "doc": "doc for field101"
+        },
+        {
+            "name": "field102",
+            "type": "string",
+            "doc": "doc for field102"
+        },
+        {
+            "name": "field103",
+            "type": "string",
+            "doc": "doc for field103"
+        },
+        {
+            "name": "field104",
+            "type": "string",
+            "doc": "doc for field104"
+        },
+        {
+            "name": "field105",
+            "type": "string",
+            "doc": "doc for field105"
+        },
+        {
+            "name": "field106",
+            "type": "string",
+            "doc": "doc for field106"
+        },
+        {
+            "name": "field107",
+            "type": "string",
+            "doc": "doc for field107"
+        },
+        {
+            "name": "field108",
+            "type": "string",
+            "doc": "doc for field108"
+        },
+        {
+            "name": "field109",
+            "type": "string",
+            "doc": "doc for field109"
+        },
+        {
+            "name": "field110",
+            "type": "string",
+            "doc": "doc for field110"
+        },
+        {
+            "name": "field111",
+            "type": "string",
+            "doc": "doc for field111"
+        },
+        {
+            "name": "field112",
+            "type": "string",
+            "doc": "doc for field112"
+        },
+        {
+            "name": "field113",
+            "type": "string",
+            "doc": "doc for field113"
+        },
+        {
+            "name": "field114",
+            "type": "string",
+            "doc": "doc for field114"
+        },
+        {
+            "name": "field115",
+            "type": "string",
+            "doc": "doc for field115"
+        },
+        {
+            "name": "field116",
+            "type": "string",
+            "doc": "doc for field116"
+        },
+        {
+            "name": "field117",
+            "type": "string",
+            "doc": "doc for field117"
+        },
+        {
+            "name": "field118",
+            "type": "string",
+            "doc": "doc for field118"
+        },
+        {
+            "name": "field119",
+            "type": "string",
+            "doc": "doc for field119"
+        },
+        {
+            "name": "field120",
+            "type": "string",
+            "doc": "doc for field120"
+        },
+        {
+            "name": "field121",
+            "type": "string",
+            "doc": "doc for field121"
+        },
+        {
+            "name": "field122",
+            "type": "string",
+            "doc": "doc for field122"
+        },
+        {
+            "name": "field123",
+            "type": "string",
+            "doc": "doc for field123"
+        },
+        {
+            "name": "field124",
+            "type": "string",
+            "doc": "doc for field124"
+        },
+        {
+            "name": "field125",
+            "type": "string",
+            "doc": "doc for field125"
+        },
+        {
+            "name": "field126",
+            "type": "string",
+            "doc": "doc for field126"
+        },
+        {
+            "name": "field127",
+            "type": "string",
+            "doc": "doc for field127"
+        },
+        {
+            "name": "field128",
+            "type": "string",
+            "doc": "doc for field128"
+        },
+        {
+            "name": "field129",
+            "type": "string",
+            "doc": "doc for field129"
+        },
+        {
+            "name": "field130",
+            "type": "string",
+            "doc": "doc for field130"
+        },
+        {
+            "name": "field131",
+            "type": "string",
+            "doc": "doc for field131"
+        },
+        {
+            "name": "field132",
+            "type": "string",
+            "doc": "doc for field132"
+        },
+        {
+            "name": "field133",
+            "type": "string",
+            "doc": "doc for field133"
+        },
+        {
+            "name": "field134",
+            "type": "string",
+            "doc": "doc for field134"
+        },
+        {
+            "name": "field135",
+            "type": "string",
+            "doc": "doc for field135"
+        },
+        {
+            "name": "field136",
+            "type": "string",
+            "doc": "doc for field136"
+        },
+        {
+            "name": "field137",
+            "type": "string",
+            "doc": "doc for field137"
+        },
+        {
+            "name": "field138",
+            "type": "string",
+            "doc": "doc for field138"
+        },
+        {
+            "name": "field139",
+            "type": "string",
+            "doc": "doc for field139"
+        },
+        {
+            "name": "field140",
+            "type": "string",
+            "doc": "doc for field140"
+        },
+        {
+            "name": "field141",
+            "type": "string",
+            "doc": "doc for field141"
+        },
+        {
+            "name": "field142",
+            "type": "string",
+            "doc": "doc for field142"
+        },
+        {
+            "name": "field143",
+            "type": "string",
+            "doc": "doc for field143"
+        },
+        {
+            "name": "field144",
+            "type": "string",
+            "doc": "doc for field144"
+        },
+        {
+            "name": "field145",
+            "type": "string",
+            "doc": "doc for field145"
+        },
+        {
+            "name": "field146",
+            "type": "string",
+            "doc": "doc for field146"
+        },
+        {
+            "name": "field147",
+            "type": "string",
+            "doc": "doc for field147"
+        },
+        {
+            "name": "field148",
+            "type": "string",
+            "doc": "doc for field148"
+        },
+        {
+            "name": "field149",
+            "type": "string",
+            "doc": "doc for field149"
+        },
+        {
+            "name": "field150",
+            "type": "string",
+            "doc": "doc for field150"
+        },
+        {
+            "name": "field151",
+            "type": "string",
+            "doc": "doc for field151"
+        },
+        {
+            "name": "field152",
+            "type": "string",
+            "doc": "doc for field152"
+        },
+        {
+            "name": "field153",
+            "type": "string",
+            "doc": "doc for field153"
+        },
+        {
+            "name": "field154",
+            "type": "string",
+            "doc": "doc for field154"
+        },
+        {
+            "name": "field155",
+            "type": "string",
+            "doc": "doc for field155"
+        },
+        {
+            "name": "field156",
+            "type": "string",
+            "doc": "doc for field156"
+        },
+        {
+            "name": "field157",
+            "type": "string",
+            "doc": "doc for field157"
+        },
+        {
+            "name": "field158",
+            "type": "string",
+            "doc": "doc for field158"
+        },
+        {
+            "name": "field159",
+            "type": "string",
+            "doc": "doc for field159"
+        },
+        {
+            "name": "field160",
+            "type": "string",
+            "doc": "doc for field160"
+        },
+        {
+            "name": "field161",
+            "type": "string",
+            "doc": "doc for field161"
+        },
+        {
+            "name": "field162",
+            "type": "string",
+            "doc": "doc for field162"
+        },
+        {
+            "name": "field163",
+            "type": "string",
+            "doc": "doc for field163"
+        },
+        {
+            "name": "field164",
+            "type": "string",
+            "doc": "doc for field164"
+        },
+        {
+            "name": "field165",
+            "type": "string",
+            "doc": "doc for field165"
+        },
+        {
+            "name": "field166",
+            "type": "string",
+            "doc": "doc for field166"
+        },
+        {
+            "name": "field167",
+            "type": "string",
+            "doc": "doc for field167"
+        },
+        {
+            "name": "field168",
+            "type": "string",
+            "doc": "doc for field168"
+        },
+        {
+            "name": "field169",
+            "type": "string",
+            "doc": "doc for field169"
+        },
+        {
+            "name": "field170",
+            "type": "string",
+            "doc": "doc for field170"
+        },
+        {
+            "name": "field171",
+            "type": "string",
+            "doc": "doc for field171"
+        },
+        {
+            "name": "field172",
+            "type": "string",
+            "doc": "doc for field172"
+        },
+        {
+            "name": "field173",
+            "type": "string",
+            "doc": "doc for field173"
+        },
+        {
+            "name": "field174",
+            "type": "string",
+            "doc": "doc for field174"
+        },
+        {
+            "name": "field175",
+            "type": "string",
+            "doc": "doc for field175"
+        },
+        {
+            "name": "field176",
+            "type": "string",
+            "doc": "doc for field176"
+        },
+        {
+            "name": "field177",
+            "type": "string",
+            "doc": "doc for field177"
+        },
+        {
+            "name": "field178",
+            "type": "string",
+            "doc": "doc for field178"
+        },
+        {
+            "name": "field179",
+            "type": "string",
+            "doc": "doc for field179"
+        },
+        {
+            "name": "field180",
+            "type": "string",
+            "doc": "doc for field180"
+        },
+        {
+            "name": "field181",
+            "type": "string",
+            "doc": "doc for field181"
+        },
+        {
+            "name": "field182",
+            "type": "string",
+            "doc": "doc for field182"
+        },
+        {
+            "name": "field183",
+            "type": "string",
+            "doc": "doc for field183"
+        },
+        {
+            "name": "field184",
+            "type": "string",
+            "doc": "doc for field184"
+        },
+        {
+            "name": "field185",
+            "type": "string",
+            "doc": "doc for field185"
+        },
+        {
+            "name": "field186",
+            "type": "string",
+            "doc": "doc for field186"
+        },
+        {
+            "name": "field187",
+            "type": "string",
+            "doc": "doc for field187"
+        },
+        {
+            "name": "field188",
+            "type": "string",
+            "doc": "doc for field188"
+        },
+        {
+            "name": "field189",
+            "type": "string",
+            "doc": "doc for field189"
+        },
+        {
+            "name": "field190",
+            "type": "string",
+            "doc": "doc for field190"
+        },
+        {
+            "name": "field191",
+            "type": "string",
+            "doc": "doc for field191"
+        },
+        {
+            "name": "field192",
+            "type": "string",
+            "doc": "doc for field192"
+        },
+        {
+            "name": "field193",
+            "type": "string",
+            "doc": "doc for field193"
+        },
+        {
+            "name": "field194",
+            "type": "string",
+            "doc": "doc for field194"
+        },
+        {
+            "name": "field195",
+            "type": "string",
+            "doc": "doc for field195"
+        },
+        {
+            "name": "field196",
+            "type": "string",
+            "doc": "doc for field196"
+        },
+        {
+            "name": "field197",
+            "type": "string",
+            "doc": "doc for field197"
+        },
+        {
+            "name": "field198",
+            "type": "string",
+            "doc": "doc for field198"
+        },
+        {
+            "name": "field199",
+            "type": "string",
+            "doc": "doc for field199"
+        },
+        {
+            "name": "field200",
+            "type": "string",
+            "doc": "doc for field200"
+        },
+        {
+            "name": "field201",
+            "type": "string",
+            "doc": "doc for field201"
+        },
+        {
+            "name": "field202",
+            "type": "string",
+            "doc": "doc for field202"
+        },
+        {
+            "name": "field203",
+            "type": "string",
+            "doc": "doc for field203"
+        },
+        {
+            "name": "field204",
+            "type": "string",
+            "doc": "doc for field204"
+        },
+        {
+            "name": "field205",
+            "type": "string",
+            "doc": "doc for field205"
+        },
+        {
+            "name": "field206",
+            "type": "string",
+            "doc": "doc for field206"
+        },
+        {
+            "name": "field207",
+            "type": "string",
+            "doc": "doc for field207"
+        },
+        {
+            "name": "field208",
+            "type": "string",
+            "doc": "doc for field208"
+        },
+        {
+            "name": "field209",
+            "type": "string",
+            "doc": "doc for field209"
+        },
+        {
+            "name": "field210",
+            "type": "string",
+            "doc": "doc for field210"
+        },
+        {
+            "name": "field211",
+            "type": "string",
+            "doc": "doc for field211"
+        },
+        {
+            "name": "field212",
+            "type": "string",
+            "doc": "doc for field212"
+        },
+        {
+            "name": "field213",
+            "type": "string",
+            "doc": "doc for field213"
+        },
+        {
+            "name": "field214",
+            "type": "string",
+            "doc": "doc for field214"
+        },
+        {
+            "name": "field215",
+            "type": "string",
+            "doc": "doc for field215"
+        },
+        {
+            "name": "field216",
+            "type": "string",
+            "doc": "doc for field216"
+        },
+        {
+            "name": "field217",
+            "type": "string",
+            "doc": "doc for field217"
+        },
+        {
+            "name": "field218",
+            "type": "string",
+            "doc": "doc for field218"
+        },
+        {
+            "name": "field219",
+            "type": "string",
+            "doc": "doc for field219"
+        },
+        {
+            "name": "field220",
+            "type": "string",
+            "doc": "doc for field220"
+        },
+        {
+            "name": "field221",
+            "type": "string",
+            "doc": "doc for field221"
+        },
+        {
+            "name": "field222",
+            "type": "string",
+            "doc": "doc for field222"
+        },
+        {
+            "name": "field223",
+            "type": "string",
+            "doc": "doc for field223"
+        },
+        {
+            "name": "field224",
+            "type": "string",
+            "doc": "doc for field224"
+        },
+        {
+            "name": "field225",
+            "type": "string",
+            "doc": "doc for field225"
+        },
+        {
+            "name": "field226",
+            "type": "string",
+            "doc": "doc for field226"
+        },
+        {
+            "name": "field227",
+            "type": "string",
+            "doc": "doc for field227"
+        },
+        {
+            "name": "field228",
+            "type": "string",
+            "doc": "doc for field228"
+        },
+        {
+            "name": "field229",
+            "type": "string",
+            "doc": "doc for field229"
+        },
+        {
+            "name": "field230",
+            "type": "string",
+            "doc": "doc for field230"
+        },
+        {
+            "name": "field231",
+            "type": "string",
+            "doc": "doc for field231"
+        },
+        {
+            "name": "field232",
+            "type": "string",
+            "doc": "doc for field232"
+        },
+        {
+            "name": "field233",
+            "type": "string",
+            "doc": "doc for field233"
+        },
+        {
+            "name": "field234",
+            "type": "string",
+            "doc": "doc for field234"
+        },
+        {
+            "name": "field235",
+            "type": "string",
+            "doc": "doc for field235"
+        },
+        {
+            "name": "field236",
+            "type": "string",
+            "doc": "doc for field236"
+        },
+        {
+            "name": "field237",
+            "type": "string",
+            "doc": "doc for field237"
+        },
+        {
+            "name": "field238",
+            "type": "string",
+            "doc": "doc for field238"
+        },
+        {
+            "name": "field239",
+            "type": "string",
+            "doc": "doc for field239"
+        },
+        {
+            "name": "field240",
+            "type": "string",
+            "doc": "doc for field240"
+        },
+        {
+            "name": "field241",
+            "type": "string",
+            "doc": "doc for field241"
+        },
+        {
+            "name": "field242",
+            "type": "string",
+            "doc": "doc for field242"
+        },
+        {
+            "name": "field243",
+            "type": "string",
+            "doc": "doc for field243"
+        },
+        {
+            "name": "field244",
+            "type": "string",
+            "doc": "doc for field244"
+        },
+        {
+            "name": "field245",
+            "type": "string",
+            "doc": "doc for field245"
+        },
+        {
+            "name": "field246",
+            "type": "string",
+            "doc": "doc for field246"
+        },
+        {
+            "name": "field247",
+            "type": "string",
+            "doc": "doc for field247"
+        },
+        {
+            "name": "field248",
+            "type": "string",
+            "doc": "doc for field248"
+        },
+        {
+            "name": "field249",
+            "type": "string",
+            "doc": "doc for field249"
+        },
+        {
+            "name": "field250",
+            "type": "string",
+            "doc": "doc for field250"
+        },
+        {
+            "name": "field251",
+            "type": "string",
+            "doc": "doc for field251"
+        },
+        {
+            "name": "field252",
+            "type": "string",
+            "doc": "doc for field252"
+        },
+        {
+            "name": "field253",
+            "type": "string",
+            "doc": "doc for field253"
+        },
+        {
+            "name": "field254",
+            "type": "string",
+            "doc": "doc for field254"
+        },
+        {
+            "name": "field255",
+            "type": "string",
+            "doc": "doc for field255"
+        },
+        {
+            "name": "field256",
+            "type": "string",
+            "doc": "doc for field256"
+        },
+        {
+            "name": "field257",
+            "type": "string",
+            "doc": "doc for field257"
+        },
+        {
+            "name": "field258",
+            "type": "string",
+            "doc": "doc for field258"
+        },
+        {
+            "name": "field259",
+            "type": "string",
+            "doc": "doc for field259"
+        },
+        {
+            "name": "field260",
+            "type": "string",
+            "doc": "doc for field260"
+        },
+        {
+            "name": "field261",
+            "type": "string",
+            "doc": "doc for field261"
+        },
+        {
+            "name": "field262",
+            "type": "string",
+            "doc": "doc for field262"
+        },
+        {
+            "name": "field263",
+            "type": "string",
+            "doc": "doc for field263"
+        },
+        {
+            "name": "field264",
+            "type": "string",
+            "doc": "doc for field264"
+        },
+        {
+            "name": "field265",
+            "type": "string",
+            "doc": "doc for field265"
+        },
+        {
+            "name": "field266",
+            "type": "string",
+            "doc": "doc for field266"
+        },
+        {
+            "name": "field267",
+            "type": "string",
+            "doc": "doc for field267"
+        },
+        {
+            "name": "field268",
+            "type": "string",
+            "doc": "doc for field268"
+        },
+        {
+            "name": "field269",
+            "type": "string",
+            "doc": "doc for field269"
+        },
+        {
+            "name": "field270",
+            "type": "string",
+            "doc": "doc for field270"
+        },
+        {
+            "name": "field271",
+            "type": "string",
+            "doc": "doc for field271"
+        },
+        {
+            "name": "field272",
+            "type": "string",
+            "doc": "doc for field272"
+        },
+        {
+            "name": "field273",
+            "type": "string",
+            "doc": "doc for field273"
+        },
+        {
+            "name": "field274",
+            "type": "string",
+            "doc": "doc for field274"
+        },
+        {
+            "name": "field275",
+            "type": "string",
+            "doc": "doc for field275"
+        },
+        {
+            "name": "field276",
+            "type": "string",
+            "doc": "doc for field276"
+        },
+        {
+            "name": "field277",
+            "type": "string",
+            "doc": "doc for field277"
+        },
+        {
+            "name": "field278",
+            "type": "string",
+            "doc": "doc for field278"
+        },
+        {
+            "name": "field279",
+            "type": "string",
+            "doc": "doc for field279"
+        },
+        {
+            "name": "field280",
+            "type": "string",
+            "doc": "doc for field280"
+        },
+        {
+            "name": "field281",
+            "type": "string",
+            "doc": "doc for field281"
+        },
+        {
+            "name": "field282",
+            "type": "string",
+            "doc": "doc for field282"
+        },
+        {
+            "name": "field283",
+            "type": "string",
+            "doc": "doc for field283"
+        },
+        {
+            "name": "field284",
+            "type": "string",
+            "doc": "doc for field284"
+        },
+        {
+            "name": "field285",
+            "type": "string",
+            "doc": "doc for field285"
+        },
+        {
+            "name": "field286",
+            "type": "string",
+            "doc": "doc for field286"
+        },
+        {
+            "name": "field287",
+            "type": "string",
+            "doc": "doc for field287"
+        },
+        {
+            "name": "field288",
+            "type": "string",
+            "doc": "doc for field288"
+        },
+        {
+            "name": "field289",
+            "type": "string",
+            "doc": "doc for field289"
+        },
+        {
+            "name": "field290",
+            "type": "string",
+            "doc": "doc for field290"
+        },
+        {
+            "name": "field291",
+            "type": "string",
+            "doc": "doc for field291"
+        },
+        {
+            "name": "field292",
+            "type": "string",
+            "doc": "doc for field292"
+        },
+        {
+            "name": "field293",
+            "type": "string",
+            "doc": "doc for field293"
+        },
+        {
+            "name": "field294",
+            "type": "string",
+            "doc": "doc for field294"
+        },
+        {
+            "name": "field295",
+            "type": "string",
+            "doc": "doc for field295"
+        },
+        {
+            "name": "field296",
+            "type": "string",
+            "doc": "doc for field296"
+        },
+        {
+            "name": "field297",
+            "type": "string",
+            "doc": "doc for field297"
+        },
+        {
+            "name": "field298",
+            "type": "string",
+            "doc": "doc for field298"
+        },
+        {
+            "name": "field299",
+            "type": "string",
+            "doc": "doc for field299"
+        },
+        {
+            "name": "field300",
+            "type": "string",
+            "doc": "doc for field300"
+        },
+        {
+            "name": "field301",
+            "type": "string",
+            "doc": "doc for field301"
+        },
+        {
+            "name": "field302",
+            "type": "string",
+            "doc": "doc for field302"
+        },
+        {
+            "name": "field303",
+            "type": "string",
+            "doc": "doc for field303"
+        },
+        {
+            "name": "field304",
+            "type": "string",
+            "doc": "doc for field304"
+        },
+        {
+            "name": "field305",
+            "type": "string",
+            "doc": "doc for field305"
+        },
+        {
+            "name": "field306",
+            "type": "string",
+            "doc": "doc for field306"
+        },
+        {
+            "name": "field307",
+            "type": "string",
+            "doc": "doc for field307"
+        },
+        {
+            "name": "field308",
+            "type": "string",
+            "doc": "doc for field308"
+        },
+        {
+            "name": "field309",
+            "type": "string",
+            "doc": "doc for field309"
+        },
+        {
+            "name": "field310",
+            "type": "string",
+            "doc": "doc for field310"
+        },
+        {
+            "name": "field311",
+            "type": "string",
+            "doc": "doc for field311"
+        },
+        {
+            "name": "field312",
+            "type": "string",
+            "doc": "doc for field312"
+        },
+        {
+            "name": "field313",
+            "type": "string",
+            "doc": "doc for field313"
+        },
+        {
+            "name": "field314",
+            "type": "string",
+            "doc": "doc for field314"
+        },
+        {
+            "name": "field315",
+            "type": "string",
+            "doc": "doc for field315"
+        },
+        {
+            "name": "field316",
+            "type": "string",
+            "doc": "doc for field316"
+        },
+        {
+            "name": "field317",
+            "type": "string",
+            "doc": "doc for field317"
+        },
+        {
+            "name": "field318",
+            "type": "string",
+            "doc": "doc for field318"
+        },
+        {
+            "name": "field319",
+            "type": "string",
+            "doc": "doc for field319"
+        },
+        {
+            "name": "field320",
+            "type": "string",
+            "doc": "doc for field320"
+        },
+        {
+            "name": "field321",
+            "type": "string",
+            "doc": "doc for field321"
+        },
+        {
+            "name": "field322",
+            "type": "string",
+            "doc": "doc for field322"
+        },
+        {
+            "name": "field323",
+            "type": "string",
+            "doc": "doc for field323"
+        },
+        {
+            "name": "field324",
+            "type": "string",
+            "doc": "doc for field324"
+        },
+        {
+            "name": "field325",
+            "type": "string",
+            "doc": "doc for field325"
+        },
+        {
+            "name": "field326",
+            "type": "string",
+            "doc": "doc for field326"
+        },
+        {
+            "name": "field327",
+            "type": "string",
+            "doc": "doc for field327"
+        },
+        {
+            "name": "field328",
+            "type": "string",
+            "doc": "doc for field328"
+        },
+        {
+            "name": "field329",
+            "type": "string",
+            "doc": "doc for field329"
+        },
+        {
+            "name": "field330",
+            "type": "string",
+            "doc": "doc for field330"
+        },
+        {
+            "name": "field331",
+            "type": "string",
+            "doc": "doc for field331"
+        },
+        {
+            "name": "field332",
+            "type": "string",
+            "doc": "doc for field332"
+        },
+        {
+            "name": "field333",
+            "type": "string",
+            "doc": "doc for field333"
+        },
+        {
+            "name": "field334",
+            "type": "string",
+            "doc": "doc for field334"
+        },
+        {
+            "name": "field335",
+            "type": "string",
+            "doc": "doc for field335"
+        },
+        {
+            "name": "field336",
+            "type": "string",
+            "doc": "doc for field336"
+        },
+        {
+            "name": "field337",
+            "type": "string",
+            "doc": "doc for field337"
+        },
+        {
+            "name": "field338",
+            "type": "string",
+            "doc": "doc for field338"
+        },
+        {
+            "name": "field339",
+            "type": "string",
+            "doc": "doc for field339"
+        },
+        {
+            "name": "field340",
+            "type": "string",
+            "doc": "doc for field340"
+        },
+        {
+            "name": "field341",
+            "type": "string",
+            "doc": "doc for field341"
+        },
+        {
+            "name": "field342",
+            "type": "string",
+            "doc": "doc for field342"
+        },
+        {
+            "name": "field343",
+            "type": "string",
+            "doc": "doc for field343"
+        },
+        {
+            "name": "field344",
+            "type": "string",
+            "doc": "doc for field344"
+        },
+        {
+            "name": "field345",
+            "type": "string",
+            "doc": "doc for field345"
+        },
+        {
+            "name": "field346",
+            "type": "string",
+            "doc": "doc for field346"
+        },
+        {
+            "name": "field347",
+            "type": "string",
+            "doc": "doc for field347"
+        },
+        {
+            "name": "field348",
+            "type": "string",
+            "doc": "doc for field348"
+        },
+        {
+            "name": "field349",
+            "type": "string",
+            "doc": "doc for field349"
+        },
+        {
+            "name": "field350",
+            "type": "string",
+            "doc": "doc for field350"
+        },
+        {
+            "name": "field351",
+            "type": "string",
+            "doc": "doc for field351"
+        },
+        {
+            "name": "field352",
+            "type": "string",
+            "doc": "doc for field352"
+        },
+        {
+            "name": "field353",
+            "type": "string",
+            "doc": "doc for field353"
+        },
+        {
+            "name": "field354",
+            "type": "string",
+            "doc": "doc for field354"
+        },
+        {
+            "name": "field355",
+            "type": "string",
+            "doc": "doc for field355"
+        },
+        {
+            "name": "field356",
+            "type": "string",
+            "doc": "doc for field356"
+        },
+        {
+            "name": "field357",
+            "type": "string",
+            "doc": "doc for field357"
+        },
+        {
+            "name": "field358",
+            "type": "string",
+            "doc": "doc for field358"
+        },
+        {
+            "name": "field359",
+            "type": "string",
+            "doc": "doc for field359"
+        },
+        {
+            "name": "field360",
+            "type": "string",
+            "doc": "doc for field360"
+        },
+        {
+            "name": "field361",
+            "type": "string",
+            "doc": "doc for field361"
+        },
+        {
+            "name": "field362",
+            "type": "string",
+            "doc": "doc for field362"
+        },
+        {
+            "name": "field363",
+            "type": "string",
+            "doc": "doc for field363"
+        },
+        {
+            "name": "field364",
+            "type": "string",
+            "doc": "doc for field364"
+        },
+        {
+            "name": "field365",
+            "type": "string",
+            "doc": "doc for field365"
+        },
+        {
+            "name": "field366",
+            "type": "string",
+            "doc": "doc for field366"
+        },
+        {
+            "name": "field367",
+            "type": "string",
+            "doc": "doc for field367"
+        },
+        {
+            "name": "field368",
+            "type": "string",
+            "doc": "doc for field368"
+        },
+        {
+            "name": "field369",
+            "type": "string",
+            "doc": "doc for field369"
+        },
+        {
+            "name": "field370",
+            "type": "string",
+            "doc": "doc for field370"
+        },
+        {
+            "name": "field371",
+            "type": "string",
+            "doc": "doc for field371"
+        },
+        {
+            "name": "field372",
+            "type": "string",
+            "doc": "doc for field372"
+        },
+        {
+            "name": "field373",
+            "type": "string",
+            "doc": "doc for field373"
+        },
+        {
+            "name": "field374",
+            "type": "string",
+            "doc": "doc for field374"
+        },
+        {
+            "name": "field375",
+            "type": "string",
+            "doc": "doc for field375"
+        },
+        {
+            "name": "field376",
+            "type": "string",
+            "doc": "doc for field376"
+        },
+        {
+            "name": "field377",
+            "type": "string",
+            "doc": "doc for field377"
+        },
+        {
+            "name": "field378",
+            "type": "string",
+            "doc": "doc for field378"
+        },
+        {
+            "name": "field379",
+            "type": "string",
+            "doc": "doc for field379"
+        },
+        {
+            "name": "field380",
+            "type": "string",
+            "doc": "doc for field380"
+        },
+        {
+            "name": "field381",
+            "type": "string",
+            "doc": "doc for field381"
+        },
+        {
+            "name": "field382",
+            "type": "string",
+            "doc": "doc for field382"
+        },
+        {
+            "name": "field383",
+            "type": "string",
+            "doc": "doc for field383"
+        },
+        {
+            "name": "field384",
+            "type": "string",
+            "doc": "doc for field384"
+        },
+        {
+            "name": "field385",
+            "type": "string",
+            "doc": "doc for field385"
+        },
+        {
+            "name": "field386",
+            "type": "string",
+            "doc": "doc for field386"
+        },
+        {
+            "name": "field387",
+            "type": "string",
+            "doc": "doc for field387"
+        },
+        {
+            "name": "field388",
+            "type": "string",
+            "doc": "doc for field388"
+        },
+        {
+            "name": "field389",
+            "type": "string",
+            "doc": "doc for field389"
+        },
+        {
+            "name": "field390",
+            "type": "string",
+            "doc": "doc for field390"
+        },
+        {
+            "name": "field391",
+            "type": "string",
+            "doc": "doc for field391"
+        },
+        {
+            "name": "field392",
+            "type": "string",
+            "doc": "doc for field392"
+        },
+        {
+            "name": "field393",
+            "type": "string",
+            "doc": "doc for field393"
+        },
+        {
+            "name": "field394",
+            "type": "string",
+            "doc": "doc for field394"
+        },
+        {
+            "name": "field395",
+            "type": "string",
+            "doc": "doc for field395"
+        },
+        {
+            "name": "field396",
+            "type": "string",
+            "doc": "doc for field396"
+        },
+        {
+            "name": "field397",
+            "type": "string",
+            "doc": "doc for field397"
+        },
+        {
+            "name": "field398",
+            "type": "string",
+            "doc": "doc for field398"
+        },
+        {
+            "name": "field399",
+            "type": "string",
+            "doc": "doc for field399"
+        },
+        {
+            "name": "field400",
+            "type": "string",
+            "doc": "doc for field400"
+        },
+        {
+            "name": "field401",
+            "type": "string",
+            "doc": "doc for field401"
+        },
+        {
+            "name": "field402",
+            "type": "string",
+            "doc": "doc for field402"
+        },
+        {
+            "name": "field403",
+            "type": "string",
+            "doc": "doc for field403"
+        },
+        {
+            "name": "field404",
+            "type": "string",
+            "doc": "doc for field404"
+        },
+        {
+            "name": "field405",
+            "type": "string",
+            "doc": "doc for field405"
+        },
+        {
+            "name": "field406",
+            "type": "string",
+            "doc": "doc for field406"
+        },
+        {
+            "name": "field407",
+            "type": "string",
+            "doc": "doc for field407"
+        },
+        {
+            "name": "field408",
+            "type": "string",
+            "doc": "doc for field408"
+        },
+        {
+            "name": "field409",
+            "type": "string",
+            "doc": "doc for field409"
+        },
+        {
+            "name": "field410",
+            "type": "string",
+            "doc": "doc for field410"
+        },
+        {
+            "name": "field411",
+            "type": "string",
+            "doc": "doc for field411"
+        },
+        {
+            "name": "field412",
+            "type": "string",
+            "doc": "doc for field412"
+        },
+        {
+            "name": "field413",
+            "type": "string",
+            "doc": "doc for field413"
+        },
+        {
+            "name": "field414",
+            "type": "string",
+            "doc": "doc for field414"
+        },
+        {
+            "name": "field415",
+            "type": "string",
+            "doc": "doc for field415"
+        },
+        {
+            "name": "field416",
+            "type": "string",
+            "doc": "doc for field416"
+        },
+        {
+            "name": "field417",
+            "type": "string",
+            "doc": "doc for field417"
+        },
+        {
+            "name": "field418",
+            "type": "string",
+            "doc": "doc for field418"
+        },
+        {
+            "name": "field419",
+            "type": "string",
+            "doc": "doc for field419"
+        },
+        {
+            "name": "field420",
+            "type": "string",
+            "doc": "doc for field420"
+        },
+        {
+            "name": "field421",
+            "type": "string",
+            "doc": "doc for field421"
+        },
+        {
+            "name": "field422",
+            "type": "string",
+            "doc": "doc for field422"
+        },
+        {
+            "name": "field423",
+            "type": "string",
+            "doc": "doc for field423"
+        },
+        {
+            "name": "field424",
+            "type": "string",
+            "doc": "doc for field424"
+        },
+        {
+            "name": "field425",
+            "type": "string",
+            "doc": "doc for field425"
+        },
+        {
+            "name": "field426",
+            "type": "string",
+            "doc": "doc for field426"
+        },
+        {
+            "name": "field427",
+            "type": "string",
+            "doc": "doc for field427"
+        },
+        {
+            "name": "field428",
+            "type": "string",
+            "doc": "doc for field428"
+        },
+        {
+            "name": "field429",
+            "type": "string",
+            "doc": "doc for field429"
+        },
+        {
+            "name": "field430",
+            "type": "string",
+            "doc": "doc for field430"
+        },
+        {
+            "name": "field431",
+            "type": "string",
+            "doc": "doc for field431"
+        },
+        {
+            "name": "field432",
+            "type": "string",
+            "doc": "doc for field432"
+        },
+        {
+            "name": "field433",
+            "type": "string",
+            "doc": "doc for field433"
+        },
+        {
+            "name": "field434",
+            "type": "string",
+            "doc": "doc for field434"
+        },
+        {
+            "name": "field435",
+            "type": "string",
+            "doc": "doc for field435"
+        },
+        {
+            "name": "field436",
+            "type": "string",
+            "doc": "doc for field436"
+        },
+        {
+            "name": "field437",
+            "type": "string",
+            "doc": "doc for field437"
+        },
+        {
+            "name": "field438",
+            "type": "string",
+            "doc": "doc for field438"
+        },
+        {
+            "name": "field439",
+            "type": "string",
+            "doc": "doc for field439"
+        },
+        {
+            "name": "field440",
+            "type": "string",
+            "doc": "doc for field440"
+        },
+        {
+            "name": "field441",
+            "type": "string",
+            "doc": "doc for field441"
+        },
+        {
+            "name": "field442",
+            "type": "string",
+            "doc": "doc for field442"
+        },
+        {
+            "name": "field443",
+            "type": "string",
+            "doc": "doc for field443"
+        },
+        {
+            "name": "field444",
+            "type": "string",
+            "doc": "doc for field444"
+        },
+        {
+            "name": "field445",
+            "type": "string",
+            "doc": "doc for field445"
+        },
+        {
+            "name": "field446",
+            "type": "string",
+            "doc": "doc for field446"
+        },
+        {
+            "name": "field447",
+            "type": "string",
+            "doc": "doc for field447"
+        },
+        {
+            "name": "field448",
+            "type": "string",
+            "doc": "doc for field448"
+        },
+        {
+            "name": "field449",
+            "type": "string",
+            "doc": "doc for field449"
+        },
+        {
+            "name": "field450",
+            "type": "string",
+            "doc": "doc for field450"
+        },
+        {
+            "name": "field451",
+            "type": "string",
+            "doc": "doc for field451"
+        },
+        {
+            "name": "field452",
+            "type": "string",
+            "doc": "doc for field452"
+        },
+        {
+            "name": "field453",
+            "type": "string",
+            "doc": "doc for field453"
+        },
+        {
+            "name": "field454",
+            "type": "string",
+            "doc": "doc for field454"
+        },
+        {
+            "name": "field455",
+            "type": "string",
+            "doc": "doc for field455"
+        },
+        {
+            "name": "field456",
+            "type": "string",
+            "doc": "doc for field456"
+        },
+        {
+            "name": "field457",
+            "type": "string",
+            "doc": "doc for field457"
+        },
+        {
+            "name": "field458",
+            "type": "string",
+            "doc": "doc for field458"
+        },
+        {
+            "name": "field459",
+            "type": "string",
+            "doc": "doc for field459"
+        },
+        {
+            "name": "field460",
+            "type": "string",
+            "doc": "doc for field460"
+        },
+        {
+            "name": "field461",
+            "type": "string",
+            "doc": "doc for field461"
+        },
+        {
+            "name": "field462",
+            "type": "string",
+            "doc": "doc for field462"
+        },
+        {
+            "name": "field463",
+            "type": "string",
+            "doc": "doc for field463"
+        },
+        {
+            "name": "field464",
+            "type": "string",
+            "doc": "doc for field464"
+        },
+        {
+            "name": "field465",
+            "type": "string",
+            "doc": "doc for field465"
+        },
+        {
+            "name": "field466",
+            "type": "string",
+            "doc": "doc for field466"
+        },
+        {
+            "name": "field467",
+            "type": "string",
+            "doc": "doc for field467"
+        },
+        {
+            "name": "field468",
+            "type": "string",
+            "doc": "doc for field468"
+        },
+        {
+            "name": "field469",
+            "type": "string",
+            "doc": "doc for field469"
+        },
+        {
+            "name": "field470",
+            "type": "string",
+            "doc": "doc for field470"
+        },
+        {
+            "name": "field471",
+            "type": "string",
+            "doc": "doc for field471"
+        },
+        {
+            "name": "field472",
+            "type": "string",
+            "doc": "doc for field472"
+        },
+        {
+            "name": "field473",
+            "type": "string",
+            "doc": "doc for field473"
+        },
+        {
+            "name": "field474",
+            "type": "string",
+            "doc": "doc for field474"
+        },
+        {
+            "name": "field475",
+            "type": "string",
+            "doc": "doc for field475"
+        },
+        {
+            "name": "field476",
+            "type": "string",
+            "doc": "doc for field476"
+        },
+        {
+            "name": "field477",
+            "type": "string",
+            "doc": "doc for field477"
+        },
+        {
+            "name": "field478",
+            "type": "string",
+            "doc": "doc for field478"
+        },
+        {
+            "name": "field479",
+            "type": "string",
+            "doc": "doc for field479"
+        },
+        {
+            "name": "field480",
+            "type": "string",
+            "doc": "doc for field480"
+        },
+        {
+            "name": "field481",
+            "type": "string",
+            "doc": "doc for field481"
+        },
+        {
+            "name": "field482",
+            "type": "string",
+            "doc": "doc for field482"
+        },
+        {
+            "name": "field483",
+            "type": "string",
+            "doc": "doc for field483"
+        },
+        {
+            "name": "field484",
+            "type": "string",
+            "doc": "doc for field484"
+        },
+        {
+            "name": "field485",
+            "type": "string",
+            "doc": "doc for field485"
+        },
+        {
+            "name": "field486",
+            "type": "string",
+            "doc": "doc for field486"
+        },
+        {
+            "name": "field487",
+            "type": "string",
+            "doc": "doc for field487"
+        },
+        {
+            "name": "field488",
+            "type": "string",
+            "doc": "doc for field488"
+        },
+        {
+            "name": "field489",
+            "type": "string",
+            "doc": "doc for field489"
+        },
+        {
+            "name": "field490",
+            "type": "string",
+            "doc": "doc for field490"
+        },
+        {
+            "name": "field491",
+            "type": "string",
+            "doc": "doc for field491"
+        },
+        {
+            "name": "field492",
+            "type": "string",
+            "doc": "doc for field492"
+        },
+        {
+            "name": "field493",
+            "type": "string",
+            "doc": "doc for field493"
+        },
+        {
+            "name": "field494",
+            "type": "string",
+            "doc": "doc for field494"
+        },
+        {
+            "name": "field495",
+            "type": "string",
+            "doc": "doc for field495"
+        },
+        {
+            "name": "field496",
+            "type": "string",
+            "doc": "doc for field496"
+        },
+        {
+            "name": "field497",
+            "type": "string",
+            "doc": "doc for field497"
+        },
+        {
+            "name": "field498",
+            "type": "string",
+            "doc": "doc for field498"
+        },
+        {
+            "name": "field499",
+            "type": "string",
+            "doc": "doc for field499"
+        },
+        {
+            "name": "field500",
+            "type": "string",
+            "doc": "doc for field500"
+        },
+        {
+            "name": "field501",
+            "type": "string",
+            "doc": "doc for field501"
+        },
+        {
+            "name": "field502",
+            "type": "string",
+            "doc": "doc for field502"
+        },
+        {
+            "name": "field503",
+            "type": "string",
+            "doc": "doc for field503"
+        },
+        {
+            "name": "field504",
+            "type": "string",
+            "doc": "doc for field504"
+        },
+        {
+            "name": "field505",
+            "type": "string",
+            "doc": "doc for field505"
+        },
+        {
+            "name": "field506",
+            "type": "string",
+            "doc": "doc for field506"
+        },
+        {
+            "name": "field507",
+            "type": "string",
+            "doc": "doc for field507"
+        },
+        {
+            "name": "field508",
+            "type": "string",
+            "doc": "doc for field508"
+        },
+        {
+            "name": "field509",
+            "type": "string",
+            "doc": "doc for field509"
+        },
+        {
+            "name": "field510",
+            "type": "string",
+            "doc": "doc for field510"
+        },
+        {
+            "name": "field511",
+            "type": "string",
+            "doc": "doc for field511"
+        },
+        {
+            "name": "field512",
+            "type": "string",
+            "doc": "doc for field512"
+        },
+        {
+            "name": "field513",
+            "type": "string",
+            "doc": "doc for field513"
+        },
+        {
+            "name": "field514",
+            "type": "string",
+            "doc": "doc for field514"
+        },
+        {
+            "name": "field515",
+            "type": "string",
+            "doc": "doc for field515"
+        },
+        {
+            "name": "field516",
+            "type": "string",
+            "doc": "doc for field516"
+        },
+        {
+            "name": "field517",
+            "type": "string",
+            "doc": "doc for field517"
+        },
+        {
+            "name": "field518",
+            "type": "string",
+            "doc": "doc for field518"
+        },
+        {
+            "name": "field519",
+            "type": "string",
+            "doc": "doc for field519"
+        },
+        {
+            "name": "field520",
+            "type": "string",
+            "doc": "doc for field520"
+        },
+        {
+            "name": "field521",
+            "type": "string",
+            "doc": "doc for field521"
+        },
+        {
+            "name": "field522",
+            "type": "string",
+            "doc": "doc for field522"
+        },
+        {
+            "name": "field523",
+            "type": "string",
+            "doc": "doc for field523"
+        },
+        {
+            "name": "field524",
+            "type": "string",
+            "doc": "doc for field524"
+        },
+        {
+            "name": "field525",
+            "type": "string",
+            "doc": "doc for field525"
+        },
+        {
+            "name": "field526",
+            "type": "string",
+            "doc": "doc for field526"
+        },
+        {
+            "name": "field527",
+            "type": "string",
+            "doc": "doc for field527"
+        },
+        {
+            "name": "field528",
+            "type": "string",
+            "doc": "doc for field528"
+        },
+        {
+            "name": "field529",
+            "type": "string",
+            "doc": "doc for field529"
+        },
+        {
+            "name": "field530",
+            "type": "string",
+            "doc": "doc for field530"
+        },
+        {
+            "name": "field531",
+            "type": "string",
+            "doc": "doc for field531"
+        },
+        {
+            "name": "field532",
+            "type": "string",
+            "doc": "doc for field532"
+        },
+        {
+            "name": "field533",
+            "type": "string",
+            "doc": "doc for field533"
+        },
+        {
+            "name": "field534",
+            "type": "string",
+            "doc": "doc for field534"
+        },
+        {
+            "name": "field535",
+            "type": "string",
+            "doc": "doc for field535"
+        },
+        {
+            "name": "field536",
+            "type": "string",
+            "doc": "doc for field536"
+        },
+        {
+            "name": "field537",
+            "type": "string",
+            "doc": "doc for field537"
+        },
+        {
+            "name": "field538",
+            "type": "string",
+            "doc": "doc for field538"
+        },
+        {
+            "name": "field539",
+            "type": "string",
+            "doc": "doc for field539"
+        },
+        {
+            "name": "field540",
+            "type": "string",
+            "doc": "doc for field540"
+        },
+        {
+            "name": "field541",
+            "type": "string",
+            "doc": "doc for field541"
+        },
+        {
+            "name": "field542",
+            "type": "string",
+            "doc": "doc for field542"
+        },
+        {
+            "name": "field543",
+            "type": "string",
+            "doc": "doc for field543"
+        },
+        {
+            "name": "field544",
+            "type": "string",
+            "doc": "doc for field544"
+        },
+        {
+            "name": "field545",
+            "type": "string",
+            "doc": "doc for field545"
+        },
+        {
+            "name": "field546",
+            "type": "string",
+            "doc": "doc for field546"
+        },
+        {
+            "name": "field547",
+            "type": "string",
+            "doc": "doc for field547"
+        },
+        {
+            "name": "field548",
+            "type": "string",
+            "doc": "doc for field548"
+        },
+        {
+            "name": "field549",
+            "type": "string",
+            "doc": "doc for field549"
+        },
+        {
+            "name": "field550",
+            "type": "string",
+            "doc": "doc for field550"
+        },
+        {
+            "name": "field551",
+            "type": "string",
+            "doc": "doc for field551"
+        },
+        {
+            "name": "field552",
+            "type": "string",
+            "doc": "doc for field552"
+        },
+        {
+            "name": "field553",
+            "type": "string",
+            "doc": "doc for field553"
+        },
+        {
+            "name": "field554",
+            "type": "string",
+            "doc": "doc for field554"
+        },
+        {
+            "name": "field555",
+            "type": "string",
+            "doc": "doc for field555"
+        },
+        {
+            "name": "field556",
+            "type": "string",
+            "doc": "doc for field556"
+        },
+        {
+            "name": "field557",
+            "type": "string",
+            "doc": "doc for field557"
+        },
+        {
+            "name": "field558",
+            "type": "string",
+            "doc": "doc for field558"
+        },
+        {
+            "name": "field559",
+            "type": "string",
+            "doc": "doc for field559"
+        },
+        {
+            "name": "field560",
+            "type": "string",
+            "doc": "doc for field560"
+        },
+        {
+            "name": "field561",
+            "type": "string",
+            "doc": "doc for field561"
+        },
+        {
+            "name": "field562",
+            "type": "string",
+            "doc": "doc for field562"
+        },
+        {
+            "name": "field563",
+            "type": "string",
+            "doc": "doc for field563"
+        },
+        {
+            "name": "field564",
+            "type": "string",
+            "doc": "doc for field564"
+        },
+        {
+            "name": "field565",
+            "type": "string",
+            "doc": "doc for field565"
+        },
+        {
+            "name": "field566",
+            "type": "string",
+            "doc": "doc for field566"
+        },
+        {
+            "name": "field567",
+            "type": "string",
+            "doc": "doc for field567"
+        },
+        {
+            "name": "field568",
+            "type": "string",
+            "doc": "doc for field568"
+        },
+        {
+            "name": "field569",
+            "type": "string",
+            "doc": "doc for field569"
+        },
+        {
+            "name": "field570",
+            "type": "string",
+            "doc": "doc for field570"
+        },
+        {
+            "name": "field571",
+            "type": "string",
+            "doc": "doc for field571"
+        },
+        {
+            "name": "field572",
+            "type": "string",
+            "doc": "doc for field572"
+        },
+        {
+            "name": "field573",
+            "type": "string",
+            "doc": "doc for field573"
+        },
+        {
+            "name": "field574",
+            "type": "string",
+            "doc": "doc for field574"
+        },
+        {
+            "name": "field575",
+            "type": "string",
+            "doc": "doc for field575"
+        },
+        {
+            "name": "field576",
+            "type": "string",
+            "doc": "doc for field576"
+        },
+        {
+            "name": "field577",
+            "type": "string",
+            "doc": "doc for field577"
+        },
+        {
+            "name": "field578",
+            "type": "string",
+            "doc": "doc for field578"
+        },
+        {
+            "name": "field579",
+            "type": "string",
+            "doc": "doc for field579"
+        },
+        {
+            "name": "field580",
+            "type": "string",
+            "doc": "doc for field580"
+        },
+        {
+            "name": "field581",
+            "type": "string",
+            "doc": "doc for field581"
+        },
+        {
+            "name": "field582",
+            "type": "string",
+            "doc": "doc for field582"
+        },
+        {
+            "name": "field583",
+            "type": "string",
+            "doc": "doc for field583"
+        },
+        {
+            "name": "field584",
+            "type": "string",
+            "doc": "doc for field584"
+        },
+        {
+            "name": "field585",
+            "type": "string",
+            "doc": "doc for field585"
+        },
+        {
+            "name": "field586",
+            "type": "string",
+            "doc": "doc for field586"
+        },
+        {
+            "name": "field587",
+            "type": "string",
+            "doc": "doc for field587"
+        },
+        {
+            "name": "field588",
+            "type": "string",
+            "doc": "doc for field588"
+        },
+        {
+            "name": "field589",
+            "type": "string",
+            "doc": "doc for field589"
+        },
+        {
+            "name": "field590",
+            "type": "string",
+            "doc": "doc for field590"
+        },
+        {
+            "name": "field591",
+            "type": "string",
+            "doc": "doc for field591"
+        },
+        {
+            "name": "field592",
+            "type": "string",
+            "doc": "doc for field592"
+        },
+        {
+            "name": "field593",
+            "type": "string",
+            "doc": "doc for field593"
+        },
+        {
+            "name": "field594",
+            "type": "string",
+            "doc": "doc for field594"
+        },
+        {
+            "name": "field595",
+            "type": "string",
+            "doc": "doc for field595"
+        },
+        {
+            "name": "field596",
+            "type": "string",
+            "doc": "doc for field596"
+        },
+        {
+            "name": "field597",
+            "type": "string",
+            "doc": "doc for field597"
+        },
+        {
+            "name": "field598",
+            "type": "string",
+            "doc": "doc for field598"
+        },
+        {
+            "name": "field599",
+            "type": "string",
+            "doc": "doc for field599"
+        },
+        {
+            "name": "field600",
+            "type": "string",
+            "doc": "doc for field600"
+        },
+        {
+            "name": "field601",
+            "type": "string",
+            "doc": "doc for field601"
+        },
+        {
+            "name": "field602",
+            "type": "string",
+            "doc": "doc for field602"
+        },
+        {
+            "name": "field603",
+            "type": "string",
+            "doc": "doc for field603"
+        },
+        {
+            "name": "field604",
+            "type": "string",
+            "doc": "doc for field604"
+        },
+        {
+            "name": "field605",
+            "type": "string",
+            "doc": "doc for field605"
+        },
+        {
+            "name": "field606",
+            "type": "string",
+            "doc": "doc for field606"
+        },
+        {
+            "name": "field607",
+            "type": "string",
+            "doc": "doc for field607"
+        },
+        {
+            "name": "field608",
+            "type": "string",
+            "doc": "doc for field608"
+        },
+        {
+            "name": "field609",
+            "type": "string",
+            "doc": "doc for field609"
+        },
+        {
+            "name": "field610",
+            "type": "string",
+            "doc": "doc for field610"
+        },
+        {
+            "name": "field611",
+            "type": "string",
+            "doc": "doc for field611"
+        },
+        {
+            "name": "field612",
+            "type": "string",
+            "doc": "doc for field612"
+        },
+        {
+            "name": "field613",
+            "type": "string",
+            "doc": "doc for field613"
+        },
+        {
+            "name": "field614",
+            "type": "string",
+            "doc": "doc for field614"
+        },
+        {
+            "name": "field615",
+            "type": "string",
+            "doc": "doc for field615"
+        },
+        {
+            "name": "field616",
+            "type": "string",
+            "doc": "doc for field616"
+        },
+        {
+            "name": "field617",
+            "type": "string",
+            "doc": "doc for field617"
+        },
+        {
+            "name": "field618",
+            "type": "string",
+            "doc": "doc for field618"
+        },
+        {
+            "name": "field619",
+            "type": "string",
+            "doc": "doc for field619"
+        },
+        {
+            "name": "field620",
+            "type": "string",
+            "doc": "doc for field620"
+        },
+        {
+            "name": "field621",
+            "type": "string",
+            "doc": "doc for field621"
+        },
+        {
+            "name": "field622",
+            "type": "string",
+            "doc": "doc for field622"
+        },
+        {
+            "name": "field623",
+            "type": "string",
+            "doc": "doc for field623"
+        },
+        {
+            "name": "field624",
+            "type": "string",
+            "doc": "doc for field624"
+        },
+        {
+            "name": "field625",
+            "type": "string",
+            "doc": "doc for field625"
+        },
+        {
+            "name": "field626",
+            "type": "string",
+            "doc": "doc for field626"
+        },
+        {
+            "name": "field627",
+            "type": "string",
+            "doc": "doc for field627"
+        },
+        {
+            "name": "field628",
+            "type": "string",
+            "doc": "doc for field628"
+        },
+        {
+            "name": "field629",
+            "type": "string",
+            "doc": "doc for field629"
+        },
+        {
+            "name": "field630",
+            "type": "string",
+            "doc": "doc for field630"
+        },
+        {
+            "name": "field631",
+            "type": "string",
+            "doc": "doc for field631"
+        },
+        {
+            "name": "field632",
+            "type": "string",
+            "doc": "doc for field632"
+        },
+        {
+            "name": "field633",
+            "type": "string",
+            "doc": "doc for field633"
+        },
+        {
+            "name": "field634",
+            "type": "string",
+            "doc": "doc for field634"
+        },
+        {
+            "name": "field635",
+            "type": "string",
+            "doc": "doc for field635"
+        },
+        {
+            "name": "field636",
+            "type": "string",
+            "doc": "doc for field636"
+        },
+        {
+            "name": "field637",
+            "type": "string",
+            "doc": "doc for field637"
+        },
+        {
+            "name": "field638",
+            "type": "string",
+            "doc": "doc for field638"
+        },
+        {
+            "name": "field639",
+            "type": "string",
+            "doc": "doc for field639"
+        },
+        {
+            "name": "field640",
+            "type": "string",
+            "doc": "doc for field640"
+        },
+        {
+            "name": "field641",
+            "type": "string",
+            "doc": "doc for field641"
+        },
+        {
+            "name": "field642",
+            "type": "string",
+            "doc": "doc for field642"
+        },
+        {
+            "name": "field643",
+            "type": "string",
+            "doc": "doc for field643"
+        },
+        {
+            "name": "field644",
+            "type": "string",
+            "doc": "doc for field644"
+        },
+        {
+            "name": "field645",
+            "type": "string",
+            "doc": "doc for field645"
+        },
+        {
+            "name": "field646",
+            "type": "string",
+            "doc": "doc for field646"
+        },
+        {
+            "name": "field647",
+            "type": "string",
+            "doc": "doc for field647"
+        },
+        {
+            "name": "field648",
+            "type": "string",
+            "doc": "doc for field648"
+        },
+        {
+            "name": "field649",
+            "type": "string",
+            "doc": "doc for field649"
+        },
+        {
+            "name": "field650",
+            "type": "string",
+            "doc": "doc for field650"
+        },
+        {
+            "name": "field651",
+            "type": "string",
+            "doc": "doc for field651"
+        },
+        {
+            "name": "field652",
+            "type": "string",
+            "doc": "doc for field652"
+        },
+        {
+            "name": "field653",
+            "type": "string",
+            "doc": "doc for field653"
+        },
+        {
+            "name": "field654",
+            "type": "string",
+            "doc": "doc for field654"
+        },
+        {
+            "name": "field655",
+            "type": "string",
+            "doc": "doc for field655"
+        },
+        {
+            "name": "field656",
+            "type": "string",
+            "doc": "doc for field656"
+        },
+        {
+            "name": "field657",
+            "type": "string",
+            "doc": "doc for field657"
+        },
+        {
+            "name": "field658",
+            "type": "string",
+            "doc": "doc for field658"
+        },
+        {
+            "name": "field659",
+            "type": "string",
+            "doc": "doc for field659"
+        },
+        {
+            "name": "field660",
+            "type": "string",
+            "doc": "doc for field660"
+        },
+        {
+            "name": "field661",
+            "type": "string",
+            "doc": "doc for field661"
+        },
+        {
+            "name": "field662",
+            "type": "string",
+            "doc": "doc for field662"
+        },
+        {
+            "name": "field663",
+            "type": "string",
+            "doc": "doc for field663"
+        },
+        {
+            "name": "field664",
+            "type": "string",
+            "doc": "doc for field664"
+        },
+        {
+            "name": "field665",
+            "type": "string",
+            "doc": "doc for field665"
+        },
+        {
+            "name": "field666",
+            "type": "string",
+            "doc": "doc for field666"
+        },
+        {
+            "name": "field667",
+            "type": "string",
+            "doc": "doc for field667"
+        },
+        {
+            "name": "field668",
+            "type": "string",
+            "doc": "doc for field668"
+        },
+        {
+            "name": "field669",
+            "type": "string",
+            "doc": "doc for field669"
+        },
+        {
+            "name": "field670",
+            "type": "string",
+            "doc": "doc for field670"
+        },
+        {
+            "name": "field671",
+            "type": "string",
+            "doc": "doc for field671"
+        },
+        {
+            "name": "field672",
+            "type": "string",
+            "doc": "doc for field672"
+        },
+        {
+            "name": "field673",
+            "type": "string",
+            "doc": "doc for field673"
+        },
+        {
+            "name": "field674",
+            "type": "string",
+            "doc": "doc for field674"
+        },
+        {
+            "name": "field675",
+            "type": "string",
+            "doc": "doc for field675"
+        },
+        {
+            "name": "field676",
+            "type": "string",
+            "doc": "doc for field676"
+        },
+        {
+            "name": "field677",
+            "type": "string",
+            "doc": "doc for field677"
+        },
+        {
+            "name": "field678",
+            "type": "string",
+            "doc": "doc for field678"
+        },
+        {
+            "name": "field679",
+            "type": "string",
+            "doc": "doc for field679"
+        },
+        {
+            "name": "field680",
+            "type": "string",
+            "doc": "doc for field680"
+        },
+        {
+            "name": "field681",
+            "type": "string",
+            "doc": "doc for field681"
+        },
+        {
+            "name": "field682",
+            "type": "string",
+            "doc": "doc for field682"
+        },
+        {
+            "name": "field683",
+            "type": "string",
+            "doc": "doc for field683"
+        },
+        {
+            "name": "field684",
+            "type": "string",
+            "doc": "doc for field684"
+        },
+        {
+            "name": "field685",
+            "type": "string",
+            "doc": "doc for field685"
+        },
+        {
+            "name": "field686",
+            "type": "string",
+            "doc": "doc for field686"
+        },
+        {
+            "name": "field687",
+            "type": "string",
+            "doc": "doc for field687"
+        },
+        {
+            "name": "field688",
+            "type": "string",
+            "doc": "doc for field688"
+        },
+        {
+            "name": "field689",
+            "type": "string",
+            "doc": "doc for field689"
+        },
+        {
+            "name": "field690",
+            "type": "string",
+            "doc": "doc for field690"
+        },
+        {
+            "name": "field691",
+            "type": "string",
+            "doc": "doc for field691"
+        },
+        {
+            "name": "field692",
+            "type": "string",
+            "doc": "doc for field692"
+        },
+        {
+            "name": "field693",
+            "type": "string",
+            "doc": "doc for field693"
+        },
+        {
+            "name": "field694",
+            "type": "string",
+            "doc": "doc for field694"
+        },
+        {
+            "name": "field695",
+            "type": "string",
+            "doc": "doc for field695"
+        },
+        {
+            "name": "field696",
+            "type": "string",
+            "doc": "doc for field696"
+        },
+        {
+            "name": "field697",
+            "type": "string",
+            "doc": "doc for field697"
+        },
+        {
+            "name": "field698",
+            "type": "string",
+            "doc": "doc for field698"
+        },
+        {
+            "name": "field699",
+            "type": "string",
+            "doc": "doc for field699"
+        },
+        {
+            "name": "field700",
+            "type": "string",
+            "doc": "doc for field700"
+        },
+        {
+            "name": "field701",
+            "type": "string",
+            "doc": "doc for field701"
+        },
+        {
+            "name": "field702",
+            "type": "string",
+            "doc": "doc for field702"
+        },
+        {
+            "name": "field703",
+            "type": "string",
+            "doc": "doc for field703"
+        },
+        {
+            "name": "field704",
+            "type": "string",
+            "doc": "doc for field704"
+        },
+        {
+            "name": "field705",
+            "type": "string",
+            "doc": "doc for field705"
+        },
+        {
+            "name": "field706",
+            "type": "string",
+            "doc": "doc for field706"
+        },
+        {
+            "name": "field707",
+            "type": "string",
+            "doc": "doc for field707"
+        },
+        {
+            "name": "field708",
+            "type": "string",
+            "doc": "doc for field708"
+        },
+        {
+            "name": "field709",
+            "type": "string",
+            "doc": "doc for field709"
+        },
+        {
+            "name": "field710",
+            "type": "string",
+            "doc": "doc for field710"
+        },
+        {
+            "name": "field711",
+            "type": "string",
+            "doc": "doc for field711"
+        },
+        {
+            "name": "field712",
+            "type": "string",
+            "doc": "doc for field712"
+        },
+        {
+            "name": "field713",
+            "type": "string",
+            "doc": "doc for field713"
+        },
+        {
+            "name": "field714",
+            "type": "string",
+            "doc": "doc for field714"
+        },
+        {
+            "name": "field715",
+            "type": "string",
+            "doc": "doc for field715"
+        },
+        {
+            "name": "field716",
+            "type": "string",
+            "doc": "doc for field716"
+        },
+        {
+            "name": "field717",
+            "type": "string",
+            "doc": "doc for field717"
+        },
+        {
+            "name": "field718",
+            "type": "string",
+            "doc": "doc for field718"
+        },
+        {
+            "name": "field719",
+            "type": "string",
+            "doc": "doc for field719"
+        },
+        {
+            "name": "field720",
+            "type": "string",
+            "doc": "doc for field720"
+        },
+        {
+            "name": "field721",
+            "type": "string",
+            "doc": "doc for field721"
+        },
+        {
+            "name": "field722",
+            "type": "string",
+            "doc": "doc for field722"
+        },
+        {
+            "name": "field723",
+            "type": "string",
+            "doc": "doc for field723"
+        },
+        {
+            "name": "field724",
+            "type": "string",
+            "doc": "doc for field724"
+        },
+        {
+            "name": "field725",
+            "type": "string",
+            "doc": "doc for field725"
+        },
+        {
+            "name": "field726",
+            "type": "string",
+            "doc": "doc for field726"
+        },
+        {
+            "name": "field727",
+            "type": "string",
+            "doc": "doc for field727"
+        },
+        {
+            "name": "field728",
+            "type": "string",
+            "doc": "doc for field728"
+        },
+        {
+            "name": "field729",
+            "type": "string",
+            "doc": "doc for field729"
+        },
+        {
+            "name": "field730",
+            "type": "string",
+            "doc": "doc for field730"
+        },
+        {
+            "name": "field731",
+            "type": "string",
+            "doc": "doc for field731"
+        },
+        {
+            "name": "field732",
+            "type": "string",
+            "doc": "doc for field732"
+        },
+        {
+            "name": "field733",
+            "type": "string",
+            "doc": "doc for field733"
+        },
+        {
+            "name": "field734",
+            "type": "string",
+            "doc": "doc for field734"
+        },
+        {
+            "name": "field735",
+            "type": "string",
+            "doc": "doc for field735"
+        },
+        {
+            "name": "field736",
+            "type": "string",
+            "doc": "doc for field736"
+        },
+        {
+            "name": "field737",
+            "type": "string",
+            "doc": "doc for field737"
+        },
+        {
+            "name": "field738",
+            "type": "string",
+            "doc": "doc for field738"
+        },
+        {
+            "name": "field739",
+            "type": "string",
+            "doc": "doc for field739"
+        },
+        {
+            "name": "field740",
+            "type": "string",
+            "doc": "doc for field740"
+        },
+        {
+            "name": "field741",
+            "type": "string",
+            "doc": "doc for field741"
+        },
+        {
+            "name": "field742",
+            "type": "string",
+            "doc": "doc for field742"
+        },
+        {
+            "name": "field743",
+            "type": "string",
+            "doc": "doc for field743"
+        },
+        {
+            "name": "field744",
+            "type": "string",
+            "doc": "doc for field744"
+        },
+        {
+            "name": "field745",
+            "type": "string",
+            "doc": "doc for field745"
+        },
+        {
+            "name": "field746",
+            "type": "string",
+            "doc": "doc for field746"
+        },
+        {
+            "name": "field747",
+            "type": "string",
+            "doc": "doc for field747"
+        },
+        {
+            "name": "field748",
+            "type": "string",
+            "doc": "doc for field748"
+        },
+        {
+            "name": "field749",
+            "type": "string",
+            "doc": "doc for field749"
+        },
+        {
+            "name": "field750",
+            "type": "string",
+            "doc": "doc for field750"
+        },
+        {
+            "name": "field751",
+            "type": "string",
+            "doc": "doc for field751"
+        },
+        {
+            "name": "field752",
+            "type": "string",
+            "doc": "doc for field752"
+        },
+        {
+            "name": "field753",
+            "type": "string",
+            "doc": "doc for field753"
+        },
+        {
+            "name": "field754",
+            "type": "string",
+            "doc": "doc for field754"
+        },
+        {
+            "name": "field755",
+            "type": "string",
+            "doc": "doc for field755"
+        },
+        {
+            "name": "field756",
+            "type": "string",
+            "doc": "doc for field756"
+        },
+        {
+            "name": "field757",
+            "type": "string",
+            "doc": "doc for field757"
+        },
+        {
+            "name": "field758",
+            "type": "string",
+            "doc": "doc for field758"
+        },
+        {
+            "name": "field759",
+            "type": "string",
+            "doc": "doc for field759"
+        },
+        {
+            "name": "field760",
+            "type": "string",
+            "doc": "doc for field760"
+        },
+        {
+            "name": "field761",
+            "type": "string",
+            "doc": "doc for field761"
+        },
+        {
+            "name": "field762",
+            "type": "string",
+            "doc": "doc for field762"
+        },
+        {
+            "name": "field763",
+            "type": "string",
+            "doc": "doc for field763"
+        },
+        {
+            "name": "field764",
+            "type": "string",
+            "doc": "doc for field764"
+        },
+        {
+            "name": "field765",
+            "type": "string",
+            "doc": "doc for field765"
+        },
+        {
+            "name": "field766",
+            "type": "string",
+            "doc": "doc for field766"
+        },
+        {
+            "name": "field767",
+            "type": "string",
+            "doc": "doc for field767"
+        },
+        {
+            "name": "field768",
+            "type": "string",
+            "doc": "doc for field768"
+        },
+        {
+            "name": "field769",
+            "type": "string",
+            "doc": "doc for field769"
+        },
+        {
+            "name": "field770",
+            "type": "string",
+            "doc": "doc for field770"
+        },
+        {
+            "name": "field771",
+            "type": "string",
+            "doc": "doc for field771"
+        },
+        {
+            "name": "field772",
+            "type": "string",
+            "doc": "doc for field772"
+        },
+        {
+            "name": "field773",
+            "type": "string",
+            "doc": "doc for field773"
+        },
+        {
+            "name": "field774",
+            "type": "string",
+            "doc": "doc for field774"
+        },
+        {
+            "name": "field775",
+            "type": "string",
+            "doc": "doc for field775"
+        },
+        {
+            "name": "field776",
+            "type": "string",
+            "doc": "doc for field776"
+        },
+        {
+            "name": "field777",
+            "type": "string",
+            "doc": "doc for field777"
+        },
+        {
+            "name": "field778",
+            "type": "string",
+            "doc": "doc for field778"
+        },
+        {
+            "name": "field779",
+            "type": "string",
+            "doc": "doc for field779"
+        },
+        {
+            "name": "field780",
+            "type": "string",
+            "doc": "doc for field780"
+        },
+        {
+            "name": "field781",
+            "type": "string",
+            "doc": "doc for field781"
+        },
+        {
+            "name": "field782",
+            "type": "string",
+            "doc": "doc for field782"
+        },
+        {
+            "name": "field783",
+            "type": "string",
+            "doc": "doc for field783"
+        },
+        {
+            "name": "field784",
+            "type": "string",
+            "doc": "doc for field784"
+        },
+        {
+            "name": "field785",
+            "type": "string",
+            "doc": "doc for field785"
+        },
+        {
+            "name": "field786",
+            "type": "string",
+            "doc": "doc for field786"
+        },
+        {
+            "name": "field787",
+            "type": "string",
+            "doc": "doc for field787"
+        },
+        {
+            "name": "field788",
+            "type": "string",
+            "doc": "doc for field788"
+        },
+        {
+            "name": "field789",
+            "type": "string",
+            "doc": "doc for field789"
+        },
+        {
+            "name": "field790",
+            "type": "string",
+            "doc": "doc for field790"
+        },
+        {
+            "name": "field791",
+            "type": "string",
+            "doc": "doc for field791"
+        },
+        {
+            "name": "field792",
+            "type": "string",
+            "doc": "doc for field792"
+        },
+        {
+            "name": "field793",
+            "type": "string",
+            "doc": "doc for field793"
+        },
+        {
+            "name": "field794",
+            "type": "string",
+            "doc": "doc for field794"
+        },
+        {
+            "name": "field795",
+            "type": "string",
+            "doc": "doc for field795"
+        },
+        {
+            "name": "field796",
+            "type": "string",
+            "doc": "doc for field796"
+        },
+        {
+            "name": "field797",
+            "type": "string",
+            "doc": "doc for field797"
+        },
+        {
+            "name": "field798",
+            "type": "string",
+            "doc": "doc for field798"
+        },
+        {
+            "name": "field799",
+            "type": "string",
+            "doc": "doc for field799"
+        },
+        {
+            "name": "field800",
+            "type": "string",
+            "doc": "doc for field800"
+        },
+        {
+            "name": "field801",
+            "type": "string",
+            "doc": "doc for field801"
+        },
+        {
+            "name": "field802",
+            "type": "string",
+            "doc": "doc for field802"
+        },
+        {
+            "name": "field803",
+            "type": "string",
+            "doc": "doc for field803"
+        },
+        {
+            "name": "field804",
+            "type": "string",
+            "doc": "doc for field804"
+        },
+        {
+            "name": "field805",
+            "type": "string",
+            "doc": "doc for field805"
+        },
+        {
+            "name": "field806",
+            "type": "string",
+            "doc": "doc for field806"
+        },
+        {
+            "name": "field807",
+            "type": "string",
+            "doc": "doc for field807"
+        },
+        {
+            "name": "field808",
+            "type": "string",
+            "doc": "doc for field808"
+        },
+        {
+            "name": "field809",
+            "type": "string",
+            "doc": "doc for field809"
+        },
+        {
+            "name": "field810",
+            "type": "string",
+            "doc": "doc for field810"
+        },
+        {
+            "name": "field811",
+            "type": "string",
+            "doc": "doc for field811"
+        },
+        {
+            "name": "field812",
+            "type": "string",
+            "doc": "doc for field812"
+        },
+        {
+            "name": "field813",
+            "type": "string",
+            "doc": "doc for field813"
+        },
+        {
+            "name": "field814",
+            "type": "string",
+            "doc": "doc for field814"
+        },
+        {
+            "name": "field815",
+            "type": "string",
+            "doc": "doc for field815"
+        },
+        {
+            "name": "field816",
+            "type": "string",
+            "doc": "doc for field816"
+        },
+        {
+            "name": "field817",
+            "type": "string",
+            "doc": "doc for field817"
+        },
+        {
+            "name": "field818",
+            "type": "string",
+            "doc": "doc for field818"
+        },
+        {
+            "name": "field819",
+            "type": "string",
+            "doc": "doc for field819"
+        },
+        {
+            "name": "field820",
+            "type": "string",
+            "doc": "doc for field820"
+        },
+        {
+            "name": "field821",
+            "type": "string",
+            "doc": "doc for field821"
+        },
+        {
+            "name": "field822",
+            "type": "string",
+            "doc": "doc for field822"
+        },
+        {
+            "name": "field823",
+            "type": "string",
+            "doc": "doc for field823"
+        },
+        {
+            "name": "field824",
+            "type": "string",
+            "doc": "doc for field824"
+        },
+        {
+            "name": "field825",
+            "type": "string",
+            "doc": "doc for field825"
+        },
+        {
+            "name": "field826",
+            "type": "string",
+            "doc": "doc for field826"
+        },
+        {
+            "name": "field827",
+            "type": "string",
+            "doc": "doc for field827"
+        },
+        {
+            "name": "field828",
+            "type": "string",
+            "doc": "doc for field828"
+        },
+        {
+            "name": "field829",
+            "type": "string",
+            "doc": "doc for field829"
+        },
+        {
+            "name": "field830",
+            "type": "string",
+            "doc": "doc for field830"
+        },
+        {
+            "name": "field831",
+            "type": "string",
+            "doc": "doc for field831"
+        },
+        {
+            "name": "field832",
+            "type": "string",
+            "doc": "doc for field832"
+        },
+        {
+            "name": "field833",
+            "type": "string",
+            "doc": "doc for field833"
+        },
+        {
+            "name": "field834",
+            "type": "string",
+            "doc": "doc for field834"
+        },
+        {
+            "name": "field835",
+            "type": "string",
+            "doc": "doc for field835"
+        },
+        {
+            "name": "field836",
+            "type": "string",
+            "doc": "doc for field836"
+        },
+        {
+            "name": "field837",
+            "type": "string",
+            "doc": "doc for field837"
+        },
+        {
+            "name": "field838",
+            "type": "string",
+            "doc": "doc for field838"
+        },
+        {
+            "name": "field839",
+            "type": "string",
+            "doc": "doc for field839"
+        },
+        {
+            "name": "field840",
+            "type": "string",
+            "doc": "doc for field840"
+        },
+        {
+            "name": "field841",
+            "type": "string",
+            "doc": "doc for field841"
+        },
+        {
+            "name": "field842",
+            "type": "string",
+            "doc": "doc for field842"
+        },
+        {
+            "name": "field843",
+            "type": "string",
+            "doc": "doc for field843"
+        },
+        {
+            "name": "field844",
+            "type": "string",
+            "doc": "doc for field844"
+        },
+        {
+            "name": "field845",
+            "type": "string",
+            "doc": "doc for field845"
+        },
+        {
+            "name": "field846",
+            "type": "string",
+            "doc": "doc for field846"
+        },
+        {
+            "name": "field847",
+            "type": "string",
+            "doc": "doc for field847"
+        },
+        {
+            "name": "field848",
+            "type": "string",
+            "doc": "doc for field848"
+        },
+        {
+            "name": "field849",
+            "type": "string",
+            "doc": "doc for field849"
+        },
+        {
+            "name": "field850",
+            "type": "string",
+            "doc": "doc for field850"
+        },
+        {
+            "name": "field851",
+            "type": "string",
+            "doc": "doc for field851"
+        },
+        {
+            "name": "field852",
+            "type": "string",
+            "doc": "doc for field852"
+        },
+        {
+            "name": "field853",
+            "type": "string",
+            "doc": "doc for field853"
+        },
+        {
+            "name": "field854",
+            "type": "string",
+            "doc": "doc for field854"
+        },
+        {
+            "name": "field855",
+            "type": "string",
+            "doc": "doc for field855"
+        },
+        {
+            "name": "field856",
+            "type": "string",
+            "doc": "doc for field856"
+        },
+        {
+            "name": "field857",
+            "type": "string",
+            "doc": "doc for field857"
+        },
+        {
+            "name": "field858",
+            "type": "string",
+            "doc": "doc for field858"
+        },
+        {
+            "name": "field859",
+            "type": "string",
+            "doc": "doc for field859"
+        },
+        {
+            "name": "field860",
+            "type": "string",
+            "doc": "doc for field860"
+        },
+        {
+            "name": "field861",
+            "type": "string",
+            "doc": "doc for field861"
+        },
+        {
+            "name": "field862",
+            "type": "string",
+            "doc": "doc for field862"
+        },
+        {
+            "name": "field863",
+            "type": "string",
+            "doc": "doc for field863"
+        },
+        {
+            "name": "field864",
+            "type": "string",
+            "doc": "doc for field864"
+        },
+        {
+            "name": "field865",
+            "type": "string",
+            "doc": "doc for field865"
+        },
+        {
+            "name": "field866",
+            "type": "string",
+            "doc": "doc for field866"
+        },
+        {
+            "name": "field867",
+            "type": "string",
+            "doc": "doc for field867"
+        },
+        {
+            "name": "field868",
+            "type": "string",
+            "doc": "doc for field868"
+        },
+        {
+            "name": "field869",
+            "type": "string",
+            "doc": "doc for field869"
+        },
+        {
+            "name": "field870",
+            "type": "string",
+            "doc": "doc for field870"
+        },
+        {
+            "name": "field871",
+            "type": "string",
+            "doc": "doc for field871"
+        },
+        {
+            "name": "field872",
+            "type": "string",
+            "doc": "doc for field872"
+        },
+        {
+            "name": "field873",
+            "type": "string",
+            "doc": "doc for field873"
+        },
+        {
+            "name": "field874",
+            "type": "string",
+            "doc": "doc for field874"
+        },
+        {
+            "name": "field875",
+            "type": "string",
+            "doc": "doc for field875"
+        },
+        {
+            "name": "field876",
+            "type": "string",
+            "doc": "doc for field876"
+        },
+        {
+            "name": "field877",
+            "type": "string",
+            "doc": "doc for field877"
+        },
+        {
+            "name": "field878",
+            "type": "string",
+            "doc": "doc for field878"
+        },
+        {
+            "name": "field879",
+            "type": "string",
+            "doc": "doc for field879"
+        },
+        {
+            "name": "field880",
+            "type": "string",
+            "doc": "doc for field880"
+        },
+        {
+            "name": "field881",
+            "type": "string",
+            "doc": "doc for field881"
+        },
+        {
+            "name": "field882",
+            "type": "string",
+            "doc": "doc for field882"
+        },
+        {
+            "name": "field883",
+            "type": "string",
+            "doc": "doc for field883"
+        },
+        {
+            "name": "field884",
+            "type": "string",
+            "doc": "doc for field884"
+        },
+        {
+            "name": "field885",
+            "type": "string",
+            "doc": "doc for field885"
+        },
+        {
+            "name": "field886",
+            "type": "string",
+            "doc": "doc for field886"
+        },
+        {
+            "name": "field887",
+            "type": "string",
+            "doc": "doc for field887"
+        },
+        {
+            "name": "field888",
+            "type": "string",
+            "doc": "doc for field888"
+        },
+        {
+            "name": "field889",
+            "type": "string",
+            "doc": "doc for field889"
+        },
+        {
+            "name": "field890",
+            "type": "string",
+            "doc": "doc for field890"
+        },
+        {
+            "name": "field891",
+            "type": "string",
+            "doc": "doc for field891"
+        },
+        {
+            "name": "field892",
+            "type": "string",
+            "doc": "doc for field892"
+        },
+        {
+            "name": "field893",
+            "type": "string",
+            "doc": "doc for field893"
+        },
+        {
+            "name": "field894",
+            "type": "string",
+            "doc": "doc for field894"
+        },
+        {
+            "name": "field895",
+            "type": "string",
+            "doc": "doc for field895"
+        },
+        {
+            "name": "field896",
+            "type": "string",
+            "doc": "doc for field896"
+        },
+        {
+            "name": "field897",
+            "type": "string",
+            "doc": "doc for field897"
+        },
+        {
+            "name": "field898",
+            "type": "string",
+            "doc": "doc for field898"
+        },
+        {
+            "name": "field899",
+            "type": "string",
+            "doc": "doc for field899"
+        },
+        {
+            "name": "field900",
+            "type": "string",
+            "doc": "doc for field900"
+        },
+        {
+            "name": "field901",
+            "type": "string",
+            "doc": "doc for field901"
+        },
+        {
+            "name": "field902",
+            "type": "string",
+            "doc": "doc for field902"
+        },
+        {
+            "name": "field903",
+            "type": "string",
+            "doc": "doc for field903"
+        },
+        {
+            "name": "field904",
+            "type": "string",
+            "doc": "doc for field904"
+        },
+        {
+            "name": "field905",
+            "type": "string",
+            "doc": "doc for field905"
+        },
+        {
+            "name": "field906",
+            "type": "string",
+            "doc": "doc for field906"
+        },
+        {
+            "name": "field907",
+            "type": "string",
+            "doc": "doc for field907"
+        },
+        {
+            "name": "field908",
+            "type": "string",
+            "doc": "doc for field908"
+        },
+        {
+            "name": "field909",
+            "type": "string",
+            "doc": "doc for field909"
+        },
+        {
+            "name": "field910",
+            "type": "string",
+            "doc": "doc for field910"
+        },
+        {
+            "name": "field911",
+            "type": "string",
+            "doc": "doc for field911"
+        },
+        {
+            "name": "field912",
+            "type": "string",
+            "doc": "doc for field912"
+        },
+        {
+            "name": "field913",
+            "type": "string",
+            "doc": "doc for field913"
+        },
+        {
+            "name": "field914",
+            "type": "string",
+            "doc": "doc for field914"
+        },
+        {
+            "name": "field915",
+            "type": "string",
+            "doc": "doc for field915"
+        },
+        {
+            "name": "field916",
+            "type": "string",
+            "doc": "doc for field916"
+        },
+        {
+            "name": "field917",
+            "type": "string",
+            "doc": "doc for field917"
+        },
+        {
+            "name": "field918",
+            "type": "string",
+            "doc": "doc for field918"
+        },
+        {
+            "name": "field919",
+            "type": "string",
+            "doc": "doc for field919"
+        },
+        {
+            "name": "field920",
+            "type": "string",
+            "doc": "doc for field920"
+        },
+        {
+            "name": "field921",
+            "type": "string",
+            "doc": "doc for field921"
+        },
+        {
+            "name": "field922",
+            "type": "string",
+            "doc": "doc for field922"
+        },
+        {
+            "name": "field923",
+            "type": "string",
+            "doc": "doc for field923"
+        },
+        {
+            "name": "field924",
+            "type": "string",
+            "doc": "doc for field924"
+        },
+        {
+            "name": "field925",
+            "type": "string",
+            "doc": "doc for field925"
+        },
+        {
+            "name": "field926",
+            "type": "string",
+            "doc": "doc for field926"
+        },
+        {
+            "name": "field927",
+            "type": "string",
+            "doc": "doc for field927"
+        },
+        {
+            "name": "field928",
+            "type": "string",
+            "doc": "doc for field928"
+        },
+        {
+            "name": "field929",
+            "type": "string",
+            "doc": "doc for field929"
+        },
+        {
+            "name": "field930",
+            "type": "string",
+            "doc": "doc for field930"
+        },
+        {
+            "name": "field931",
+            "type": "string",
+            "doc": "doc for field931"
+        },
+        {
+            "name": "field932",
+            "type": "string",
+            "doc": "doc for field932"
+        },
+        {
+            "name": "field933",
+            "type": "string",
+            "doc": "doc for field933"
+        },
+        {
+            "name": "field934",
+            "type": "string",
+            "doc": "doc for field934"
+        },
+        {
+            "name": "field935",
+            "type": "string",
+            "doc": "doc for field935"
+        },
+        {
+            "name": "field936",
+            "type": "string",
+            "doc": "doc for field936"
+        },
+        {
+            "name": "field937",
+            "type": "string",
+            "doc": "doc for field937"
+        },
+        {
+            "name": "field938",
+            "type": "string",
+            "doc": "doc for field938"
+        },
+        {
+            "name": "field939",
+            "type": "string",
+            "doc": "doc for field939"
+        },
+        {
+            "name": "field940",
+            "type": "string",
+            "doc": "doc for field940"
+        },
+        {
+            "name": "field941",
+            "type": "string",
+            "doc": "doc for field941"
+        },
+        {
+            "name": "field942",
+            "type": "string",
+            "doc": "doc for field942"
+        },
+        {
+            "name": "field943",
+            "type": "string",
+            "doc": "doc for field943"
+        },
+        {
+            "name": "field944",
+            "type": "string",
+            "doc": "doc for field944"
+        },
+        {
+            "name": "field945",
+            "type": "string",
+            "doc": "doc for field945"
+        },
+        {
+            "name": "field946",
+            "type": "string",
+            "doc": "doc for field946"
+        },
+        {
+            "name": "field947",
+            "type": "string",
+            "doc": "doc for field947"
+        },
+        {
+            "name": "field948",
+            "type": "string",
+            "doc": "doc for field948"
+        },
+        {
+            "name": "field949",
+            "type": "string",
+            "doc": "doc for field949"
+        },
+        {
+            "name": "field950",
+            "type": "string",
+            "doc": "doc for field950"
+        },
+        {
+            "name": "field951",
+            "type": "string",
+            "doc": "doc for field951"
+        },
+        {
+            "name": "field952",
+            "type": "string",
+            "doc": "doc for field952"
+        },
+        {
+            "name": "field953",
+            "type": "string",
+            "doc": "doc for field953"
+        },
+        {
+            "name": "field954",
+            "type": "string",
+            "doc": "doc for field954"
+        },
+        {
+            "name": "field955",
+            "type": "string",
+            "doc": "doc for field955"
+        },
+        {
+            "name": "field956",
+            "type": "string",
+            "doc": "doc for field956"
+        },
+        {
+            "name": "field957",
+            "type": "string",
+            "doc": "doc for field957"
+        },
+        {
+            "name": "field958",
+            "type": "string",
+            "doc": "doc for field958"
+        },
+        {
+            "name": "field959",
+            "type": "string",
+            "doc": "doc for field959"
+        },
+        {
+            "name": "field960",
+            "type": "string",
+            "doc": "doc for field960"
+        },
+        {
+            "name": "field961",
+            "type": "string",
+            "doc": "doc for field961"
+        },
+        {
+            "name": "field962",
+            "type": "string",
+            "doc": "doc for field962"
+        },
+        {
+            "name": "field963",
+            "type": "string",
+            "doc": "doc for field963"
+        },
+        {
+            "name": "field964",
+            "type": "string",
+            "doc": "doc for field964"
+        },
+        {
+            "name": "field965",
+            "type": "string",
+            "doc": "doc for field965"
+        },
+        {
+            "name": "field966",
+            "type": "string",
+            "doc": "doc for field966"
+        },
+        {
+            "name": "field967",
+            "type": "string",
+            "doc": "doc for field967"
+        },
+        {
+            "name": "field968",
+            "type": "string",
+            "doc": "doc for field968"
+        },
+        {
+            "name": "field969",
+            "type": "string",
+            "doc": "doc for field969"
+        },
+        {
+            "name": "field970",
+            "type": "string",
+            "doc": "doc for field970"
+        },
+        {
+            "name": "field971",
+            "type": "string",
+            "doc": "doc for field971"
+        },
+        {
+            "name": "field972",
+            "type": "string",
+            "doc": "doc for field972"
+        },
+        {
+            "name": "field973",
+            "type": "string",
+            "doc": "doc for field973"
+        },
+        {
+            "name": "field974",
+            "type": "string",
+            "doc": "doc for field974"
+        },
+        {
+            "name": "field975",
+            "type": "string",
+            "doc": "doc for field975"
+        },
+        {
+            "name": "field976",
+            "type": "string",
+            "doc": "doc for field976"
+        },
+        {
+            "name": "field977",
+            "type": "string",
+            "doc": "doc for field977"
+        },
+        {
+            "name": "field978",
+            "type": "string",
+            "doc": "doc for field978"
+        },
+        {
+            "name": "field979",
+            "type": "string",
+            "doc": "doc for field979"
+        },
+        {
+            "name": "field980",
+            "type": "string",
+            "doc": "doc for field980"
+        },
+        {
+            "name": "field981",
+            "type": "string",
+            "doc": "doc for field981"
+        },
+        {
+            "name": "field982",
+            "type": "string",
+            "doc": "doc for field982"
+        },
+        {
+            "name": "field983",
+            "type": "string",
+            "doc": "doc for field983"
+        },
+        {
+            "name": "field984",
+            "type": "string",
+            "doc": "doc for field984"
+        },
+        {
+            "name": "field985",
+            "type": "string",
+            "doc": "doc for field985"
+        },
+        {
+            "name": "field986",
+            "type": "string",
+            "doc": "doc for field986"
+        },
+        {
+            "name": "field987",
+            "type": "string",
+            "doc": "doc for field987"
+        },
+        {
+            "name": "field988",
+            "type": "string",
+            "doc": "doc for field988"
+        },
+        {
+            "name": "field989",
+            "type": "string",
+            "doc": "doc for field989"
+        },
+        {
+            "name": "field990",
+            "type": "string",
+            "doc": "doc for field990"
+        },
+        {
+            "name": "field991",
+            "type": "string",
+            "doc": "doc for field991"
+        },
+        {
+            "name": "field992",
+            "type": "string",
+            "doc": "doc for field992"
+        },
+        {
+            "name": "field993",
+            "type": "string",
+            "doc": "doc for field993"
+        },
+        {
+            "name": "field994",
+            "type": "string",
+            "doc": "doc for field994"
+        },
+        {
+            "name": "field995",
+            "type": "string",
+            "doc": "doc for field995"
+        },
+        {
+            "name": "field996",
+            "type": "string",
+            "doc": "doc for field996"
+        },
+        {
+            "name": "field997",
+            "type": "string",
+            "doc": "doc for field997"
+        },
+        {
+            "name": "field998",
+            "type": "string",
+            "doc": "doc for field998"
+        },
+        {
+            "name": "field999",
+            "type": "string",
+            "doc": "doc for field999"
+        },
+        {
+            "name": "field1000",
+            "type": "string",
+            "doc": "doc for field1000"
+        },
+        {
+            "name": "field1001",
+            "type": "string",
+            "doc": "doc for field1001"
+        },
+        {
+            "name": "field1002",
+            "type": "string",
+            "doc": "doc for field1002"
+        },
+        {
+            "name": "field1003",
+            "type": "string",
+            "doc": "doc for field1003"
+        },
+        {
+            "name": "field1004",
+            "type": "string",
+            "doc": "doc for field1004"
+        },
+        {
+            "name": "field1005",
+            "type": "string",
+            "doc": "doc for field1005"
+        },
+        {
+            "name": "field1006",
+            "type": "string",
+            "doc": "doc for field1006"
+        },
+        {
+            "name": "field1007",
+            "type": "string",
+            "doc": "doc for field1007"
+        },
+        {
+            "name": "field1008",
+            "type": "string",
+            "doc": "doc for field1008"
+        },
+        {
+            "name": "field1009",
+            "type": "string",
+            "doc": "doc for field1009"
+        },
+        {
+            "name": "field1010",
+            "type": "string",
+            "doc": "doc for field1010"
+        },
+        {
+            "name": "field1011",
+            "type": "string",
+            "doc": "doc for field1011"
+        },
+        {
+            "name": "field1012",
+            "type": "string",
+            "doc": "doc for field1012"
+        },
+        {
+            "name": "field1013",
+            "type": "string",
+            "doc": "doc for field1013"
+        },
+        {
+            "name": "field1014",
+            "type": "string",
+            "doc": "doc for field1014"
+        },
+        {
+            "name": "field1015",
+            "type": "string",
+            "doc": "doc for field1015"
+        },
+        {
+            "name": "field1016",
+            "type": "string",
+            "doc": "doc for field1016"
+        },
+        {
+            "name": "field1017",
+            "type": "string",
+            "doc": "doc for field1017"
+        },
+        {
+            "name": "field1018",
+            "type": "string",
+            "doc": "doc for field1018"
+        },
+        {
+            "name": "field1019",
+            "type": "string",
+            "doc": "doc for field1019"
+        },
+        {
+            "name": "field1020",
+            "type": "string",
+            "doc": "doc for field1020"
+        },
+        {
+            "name": "field1021",
+            "type": "string",
+            "doc": "doc for field1021"
+        },
+        {
+            "name": "field1022",
+            "type": "string",
+            "doc": "doc for field1022"
+        },
+        {
+            "name": "field1023",
+            "type": "string",
+            "doc": "doc for field1023"
+        },
+        {
+            "name": "field1024",
+            "type": "string",
+            "doc": "doc for field1024"
+        },
+        {
+            "name": "field1025",
+            "type": "string",
+            "doc": "doc for field1025"
+        },
+        {
+            "name": "field1026",
+            "type": "string",
+            "doc": "doc for field1026"
+        },
+        {
+            "name": "field1027",
+            "type": "string",
+            "doc": "doc for field1027"
+        },
+        {
+            "name": "field1028",
+            "type": "string",
+            "doc": "doc for field1028"
+        },
+        {
+            "name": "field1029",
+            "type": "string",
+            "doc": "doc for field1029"
+        },
+        {
+            "name": "field1030",
+            "type": "string",
+            "doc": "doc for field1030"
+        },
+        {
+            "name": "field1031",
+            "type": "string",
+            "doc": "doc for field1031"
+        },
+        {
+            "name": "field1032",
+            "type": "string",
+            "doc": "doc for field1032"
+        },
+        {
+            "name": "field1033",
+            "type": "string",
+            "doc": "doc for field1033"
+        },
+        {
+            "name": "field1034",
+            "type": "string",
+            "doc": "doc for field1034"
+        },
+        {
+            "name": "field1035",
+            "type": "string",
+            "doc": "doc for field1035"
+        },
+        {
+            "name": "field1036",
+            "type": "string",
+            "doc": "doc for field1036"
+        },
+        {
+            "name": "field1037",
+            "type": "string",
+            "doc": "doc for field1037"
+        },
+        {
+            "name": "field1038",
+            "type": "string",
+            "doc": "doc for field1038"
+        },
+        {
+            "name": "field1039",
+            "type": "string",
+            "doc": "doc for field1039"
+        },
+        {
+            "name": "field1040",
+            "type": "string",
+            "doc": "doc for field1040"
+        },
+        {
+            "name": "field1041",
+            "type": "string",
+            "doc": "doc for field1041"
+        },
+        {
+            "name": "field1042",
+            "type": "string",
+            "doc": "doc for field1042"
+        },
+        {
+            "name": "field1043",
+            "type": "string",
+            "doc": "doc for field1043"
+        },
+        {
+            "name": "field1044",
+            "type": "string",
+            "doc": "doc for field1044"
+        },
+        {
+            "name": "field1045",
+            "type": "string",
+            "doc": "doc for field1045"
+        },
+        {
+            "name": "field1046",
+            "type": "string",
+            "doc": "doc for field1046"
+        },
+        {
+            "name": "field1047",
+            "type": "string",
+            "doc": "doc for field1047"
+        },
+        {
+            "name": "field1048",
+            "type": "string",
+            "doc": "doc for field1048"
+        },
+        {
+            "name": "field1049",
+            "type": "string",
+            "doc": "doc for field1049"
+        },
+        {
+            "name": "field1050",
+            "type": "string",
+            "doc": "doc for field1050"
+        },
+        {
+            "name": "field1051",
+            "type": "string",
+            "doc": "doc for field1051"
+        },
+        {
+            "name": "field1052",
+            "type": "string",
+            "doc": "doc for field1052"
+        },
+        {
+            "name": "field1053",
+            "type": "string",
+            "doc": "doc for field1053"
+        },
+        {
+            "name": "field1054",
+            "type": "string",
+            "doc": "doc for field1054"
+        },
+        {
+            "name": "field1055",
+            "type": "string",
+            "doc": "doc for field1055"
+        },
+        {
+            "name": "field1056",
+            "type": "string",
+            "doc": "doc for field1056"
+        },
+        {
+            "name": "field1057",
+            "type": "string",
+            "doc": "doc for field1057"
+        },
+        {
+            "name": "field1058",
+            "type": "string",
+            "doc": "doc for field1058"
+        },
+        {
+            "name": "field1059",
+            "type": "string",
+            "doc": "doc for field1059"
+        },
+        {
+            "name": "field1060",
+            "type": "string",
+            "doc": "doc for field1060"
+        },
+        {
+            "name": "field1061",
+            "type": "string",
+            "doc": "doc for field1061"
+        },
+        {
+            "name": "field1062",
+            "type": "string",
+            "doc": "doc for field1062"
+        },
+        {
+            "name": "field1063",
+            "type": "string",
+            "doc": "doc for field1063"
+        },
+        {
+            "name": "field1064",
+            "type": "string",
+            "doc": "doc for field1064"
+        },
+        {
+            "name": "field1065",
+            "type": "string",
+            "doc": "doc for field1065"
+        },
+        {
+            "name": "field1066",
+            "type": "string",
+            "doc": "doc for field1066"
+        },
+        {
+            "name": "field1067",
+            "type": "string",
+            "doc": "doc for field1067"
+        },
+        {
+            "name": "field1068",
+            "type": "string",
+            "doc": "doc for field1068"
+        },
+        {
+            "name": "field1069",
+            "type": "string",
+            "doc": "doc for field1069"
+        },
+        {
+            "name": "field1070",
+            "type": "string",
+            "doc": "doc for field1070"
+        },
+        {
+            "name": "field1071",
+            "type": "string",
+            "doc": "doc for field1071"
+        },
+        {
+            "name": "field1072",
+            "type": "string",
+            "doc": "doc for field1072"
+        },
+        {
+            "name": "field1073",
+            "type": "string",
+            "doc": "doc for field1073"
+        }
+    ]
+}


### PR DESCRIPTION
Using writeUTF limits the avro schema definition to 65535 characters (http://docs.oracle.com/javase/7/docs/api/java/io/DataOutput.html#writeUTF%28java.lang.String%29).  This request includes a generated "fake" schema to demonstrate the issue.